### PR TITLE
Introduce async actions with redux-observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"flow": "flow"
 	},
 	"dependencies": {
+		"axios": "^0.17.1",
 		"lodash": "^4.17.4",
 		"prop-types": "^15.6.0",
 		"react": "16.0.0-beta.5",
@@ -17,7 +18,9 @@
 		"react-redux": "^5.0.6",
 		"redux": "^3.7.2",
 		"redux-actions": "^2.2.1",
-		"redux-devtools-extension": "^2.13.2"
+		"redux-devtools-extension": "^2.13.2",
+		"redux-observable": "^0.17.0",
+		"rxjs": "^5.5.6"
 	},
 	"devDependencies": {
 		"babel-jest": "21.2.0",

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropType from 'prop-types';
+import _ from 'lodash';
 import { Text, View, Button } from 'react-native';
 import { connect } from 'react-redux';
 
@@ -12,11 +13,17 @@ function getTitle(isPatron) {
   return `${isPatron ? 'Disable' : 'Enable'} Patreon`;
 }
 
-const PatreonScreen = ({ isPatron, enable, disable }) => (
-  <View style={styles.container}>
-    <Text>
-      Placeholder Patreon screen
-    </Text>
+function PatreonControl({
+  isPatron,
+  loading,
+  enable,
+  disable,
+}) {
+  if (loading) {
+    return <Text>Loading...</Text>;
+  }
+
+  return (
     <Button
       onPress={() => {
         if (isPatron) {
@@ -27,13 +34,53 @@ const PatreonScreen = ({ isPatron, enable, disable }) => (
       }}
       title={getTitle(isPatron)}
     />
+  );
+}
+
+PatreonControl.propTypes = {
+  isPatron: PropType.bool.isRequired,
+  loading: PropType.bool.isRequired,
+  enable: PropType.func.isRequired,
+  disable: PropType.func.isRequired,
+};
+
+const patreonStyles = {
+  error: {
+    color: 'red',
+  },
+};
+
+function PatreonError({ error }) {
+  if (!_.isError(error)) {
+    return null;
+  }
+
+  return <Text style={patreonStyles.error}>{error.message}</Text>;
+}
+
+PatreonError.propTypes = {
+  error: PropType.instanceOf(Error),
+};
+PatreonError.defaultProps = {
+  error: null,
+};
+
+const PatreonScreen = props => (
+  <View style={styles.container}>
+    <Text>
+      Placeholder Patreon screen
+    </Text>
+    <PatreonControl {...props} />
+    <PatreonError error={props.error} />
   </View>
 );
 
 PatreonScreen.propTypes = {
-  isPatron: PropType.bool.isRequired,
-  enable: PropType.func.isRequired,
-  disable: PropType.func.isRequired,
+  error: PropType.instanceOf(Error),
+};
+
+PatreonScreen.defaultProps = {
+  error: null,
 };
 
 PatreonScreen.navigationOptions = ({ navigation }) => ({
@@ -44,6 +91,8 @@ PatreonScreen.navigationOptions = ({ navigation }) => ({
 function mapStateToProps(state) {
   return {
     isPatron: selectors.isPatron(state),
+    loading: selectors.loading(state),
+    error: selectors.error(state),
   };
 }
 

--- a/src/state/ducks/patreon/actions.js
+++ b/src/state/ducks/patreon/actions.js
@@ -4,3 +4,7 @@ import * as types from './types';
 
 export const enable = createAction(types.ENABLE_PATREON);
 export const disable = createAction(types.DISABLE_PATREON);
+
+export const patreonEnabled = createAction(types.PATREON_ENABLED);
+export const patreonDisabled = createAction(types.PATREON_DISABLED);
+export const patreonError = createAction(types.PATREON_ERROR);

--- a/src/state/ducks/patreon/epic.js
+++ b/src/state/ducks/patreon/epic.js
@@ -1,0 +1,42 @@
+import { combineEpics } from 'redux-observable';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/operator/mapTo';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/fromPromise';
+import axios from 'axios';
+
+import { ENABLE_PATREON, DISABLE_PATREON } from './types';
+import {
+  patreonEnabled,
+  patreonDisabled,
+  patreonError,
+} from './actions';
+
+function sendFakePatreonRequest() {
+  const errorProbability = 0.4;
+  const endpoint = (Math.random() < errorProbability) ? 'status/429' : 'post';
+
+  const url = `https://httpbin.org/${endpoint}`;
+  const json = { foo: 'bar' };
+  return Observable.fromPromise(axios.post(url, json));
+}
+
+const enablePatreonEpic = action$ =>
+  action$.ofType(ENABLE_PATREON)
+    .switchMap(() => (
+      sendFakePatreonRequest()
+        .mapTo(patreonEnabled())
+        .catch(error => Observable.of(patreonError(error)))
+    ));
+
+const disablePatreonEpic = action$ =>
+  action$.ofType(DISABLE_PATREON)
+    .switchMap(() => (
+      sendFakePatreonRequest()
+        .mapTo(patreonDisabled())
+        .catch(error => Observable.of(patreonError(error)))
+    ));
+
+export default combineEpics(enablePatreonEpic, disablePatreonEpic);

--- a/src/state/ducks/patreon/index.js
+++ b/src/state/ducks/patreon/index.js
@@ -1,2 +1,3 @@
 export { enable, disable } from './actions';
+export { default as epic } from './epic';
 export { default } from './reducer';

--- a/src/state/ducks/patreon/reducer.js
+++ b/src/state/ducks/patreon/reducer.js
@@ -1,16 +1,40 @@
 import { handleActions } from '../../utils/reduxActions';
 
-import { ENABLE_PATREON, DISABLE_PATREON } from './types';
+import {
+  ENABLE_PATREON,
+  DISABLE_PATREON,
+  PATREON_ENABLED,
+  PATREON_DISABLED,
+  PATREON_ERROR,
+} from './types';
 
 const defaultState = {
   enabled: false,
+  loading: false,
 };
 
 export default handleActions({
-  [ENABLE_PATREON]: () => ({
-    enabled: true,
+  [ENABLE_PATREON]: state => ({
+    ...state,
+    error: null,
+    loading: true,
   }),
-  [DISABLE_PATREON]: () => ({
+  [DISABLE_PATREON]: state => ({
+    ...state,
+    error: null,
+    loading: true,
+  }),
+  [PATREON_ENABLED]: () => ({
+    enabled: true,
+    loading: false,
+  }),
+  [PATREON_DISABLED]: () => ({
     enabled: false,
+    loading: false,
+  }),
+  [PATREON_ERROR]: (state, action) => ({
+    ...state,
+    error: action.payload,
+    loading: false,
   }),
 }, defaultState);

--- a/src/state/ducks/patreon/selectors.js
+++ b/src/state/ducks/patreon/selectors.js
@@ -1,3 +1,11 @@
 export function isPatron(state) {
   return state.patreon.enabled;
 }
+
+export function loading(state) {
+  return state.patreon.loading;
+}
+
+export function error(state) {
+  return state.patreon.error;
+}

--- a/src/state/ducks/patreon/types.js
+++ b/src/state/ducks/patreon/types.js
@@ -2,3 +2,7 @@ import { scopedType } from '../../utils';
 
 export const ENABLE_PATREON = scopedType('patreon/ENABLE');
 export const DISABLE_PATREON = scopedType('patreon/DISABLE');
+
+export const PATREON_ENABLED = scopedType('patreon/ENABLED');
+export const PATREON_DISABLED = scopedType('patreon/DISABLED');
+export const PATREON_ERROR = scopedType('patreon/ERROR');

--- a/src/state/epics.js
+++ b/src/state/epics.js
@@ -1,0 +1,5 @@
+import patreonEpic from './ducks/patreon/epic';
+
+export default [
+  patreonEpic,
+];

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,12 +1,14 @@
-import { combineReducers, createStore } from 'redux';
+import { combineReducers, createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
+import { combineEpics, createEpicMiddleware } from 'redux-observable';
 
 import * as reducers from './ducks';
+import epics from './epics';
 
 export default function configureStore() {
   const reducer = combineReducers(reducers);
-  return createStore(
-    reducer,
-    composeWithDevTools(),
-  );
+  const epic = combineEpics(...epics);
+  const epicMiddleware = createEpicMiddleware(epic);
+  const enhancer = composeWithDevTools(applyMiddleware(epicMiddleware));
+  return createStore(reducer, enhancer);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,6 +259,13 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"
+  dependencies:
+    follow-redirects "^1.2.5"
+    is-buffer "^1.1.5"
+
 axobject-query@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
@@ -1903,6 +1910,12 @@ flat-cache@^1.2.1:
 flow-bin@0.53.0:
   version "0.53.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.53.0.tgz#f7830e609ca02b12db4127114213cccc7c0771b9"
+
+follow-redirects@^1.2.5:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.3.0.tgz#f684871fc116d2e329fda55ef67687f4fabc905c"
+  dependencies:
+    debug "^3.1.0"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -3981,6 +3994,10 @@ redux-devtools-extension@^2.13.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz#e0f9a8e8dfca7c17be92c7124958a3b94eb2911d"
 
+redux-observable@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.17.0.tgz#23e29e3f3c39204b7ed6a14b67a29e317c03106b"
+
 redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
@@ -4188,6 +4205,12 @@ rx-lite-aggregates@^4.0.8:
 rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
+rxjs@^5.5.6:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -4500,6 +4523,10 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 symbol-observable@^1.0.3:
   version "1.1.0"


### PR DESCRIPTION
## Description

- Add [redux-observable] and two [epics] for Patreon actions
  - Fake API requests; currently they hit httpbin.org
  - Randomly returns 429 responses for testing error handling
- Add Patreon epic to Patreon duck
  - As suggested in the [re-ducks] docs
- ~Structured epics similarly to ducks~
  - ~As (sort of) suggested in the redux-observable docs~
- ~Moved `{ENABLE,DISABLE}_PATREON` actions to epic duck~
  - "Epic duck" is totally what I'm calling those things

[redux-observable]: https://redux-observable.js.org/
[epics]: https://redux-observable.js.org/docs/basics/Epics.html
[re-ducks]: https://github.com/alexnm/re-ducks#operations

## Motivation and Context
See #11, but for async actions.

## How Has This Been Tested?
These changes only affect the **Manage Patreon** screen. I clicked
"Enable Patreon" and "Disable Patreon" many times. I used Redux DevTools
to verify that the network requests were being sent, and that the successes
and errors matched what I saw in the UI.

## Screenshots (if appropriate):
![Epic duck](https://i.imgur.com/IppKJ.jpg)
Despite the changes above, I like this duck. I'm keeping it.