### PR TITLE
Add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+# iOS CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/ios-migrating-from-1-2/ for more details
+#
+version: 2
+
+defaults: &defaults
+  working_directory: ~/project
+  docker:
+    - image: circleci/node:8.9.3-stretch
+
+jobs:
+  install_dependencies:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          key: js-deps-{{ checksum "yarn.lock" }}
+      - run: yarn
+      - save_cache:
+          key: js-deps-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+  eslint:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          key: js-deps-{{ checksum "yarn.lock" }}
+      - run: mkdir -p ~/reports/eslint
+      - run: yarn lint --format junit --output-file ../reports/eslint/eslint.xml
+      - store_test_results:
+          path: ~/reports
+
+  unit_tests:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          key: js-deps-{{ checksum "yarn.lock" }}
+      - run: mkdir -p ~/reports/jest
+      - run:
+          name: Unit tests
+          command: yarn test --ci --testResultsProcessor="jest-junit"
+          environment:
+            JEST_JUNIT_OUTPUT: "../reports/jest/js-test-results.xml"
+      - store_test_results:
+          path: ~/reports
+
+workflows:
+  version: 2
+  main:
+    jobs:
+      - install_dependencies
+      - eslint:
+          requires:
+            - install_dependencies
+      - unit_tests:
+          requires:
+            - install_dependencies

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 		"start": "node node_modules/react-native/local-cli/cli.js start",
 		"test": "jest",
 		"lint": "./node_modules/.bin/eslint index.js ./src/* ./__tests__/*",
-		"flow": "flow"
+		"flow": "flow",
+		"validateci": "./scripts/validate-ci-config"
 	},
 	"dependencies": {
 		"axios": "^0.17.1",
@@ -33,6 +34,7 @@
 		"eslint-plugin-react": "^7.4.0",
 		"flow-bin": "0.53.0",
 		"jest": "21.2.1",
+		"jest-junit": "^3.4.1",
 		"pre-commit": "^1.2.2",
 		"react-test-renderer": "16.0.0-beta.5"
 	},
@@ -45,6 +47,7 @@
 	"comment": "flow is disabled in pre-commit because react-navigation breaks it",
 	"pre-commit": [
 		"lint",
-		"test"
+		"test",
+		"validateci"
 	]
 }

--- a/scripts/circleci
+++ b/scripts/circleci
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -e
+
+PICARD_REPO="circleci/picard"
+
+PICARD_CLI_URL="https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci"
+PICARD_CLI_FILE="$0"
+
+CIRCLECI_DIR="$HOME/.circleci"
+CURRENT_DIGEST_FILE="$CIRCLECI_DIR/current_picard_digest"
+LATEST_DIGEST_FILE="$CIRCLECI_DIR/latest_picard_digest"
+
+UNKNOWN_DIGEST=""
+
+CLI_VERSION="0.0.4626-404b4b8"
+
+# Pull `latest` tag from docker repo and write digest into the file
+pull_latest_image() {
+  latest_image=$(docker pull $PICARD_REPO | grep -o "sha256.*$")
+  echo $latest_image > $LATEST_DIGEST_FILE
+}
+
+# Write given digest into the file
+update_current_digest() {
+  version="$@"
+  echo $version > $CURRENT_DIGEST_FILE
+}
+
+# Read latest digest from file
+get_latest_digest() {
+  if [ -e "$LATEST_DIGEST_FILE" ];
+  then
+    echo $(cat $LATEST_DIGEST_FILE)
+  else
+    echo $UNKNOWN_DIGEST
+  fi
+}
+
+# Read current digest from file
+get_current_digest() {
+  if [ -e "$CURRENT_DIGEST_FILE" ];
+  then
+    echo $(cat $CURRENT_DIGEST_FILE)
+  else
+    echo $UNKNOWN_DIGEST
+  fi
+}
+
+# Compare latest_digest and current_digest
+is_update_available() {
+  current=$(get_current_digest)
+  latest=$(get_latest_digest)
+
+  return $([[ $latest != $UNKNOWN_DIGEST ]] && [[ $current != $latest ]])
+}
+
+# Printing version of this script
+print_cli_version() {
+  echo "circleci version:" $CLI_VERSION
+}
+
+update_picard_cli() {
+  cmd_prefix=""
+  if ! [[ -w $PICARD_CLI_FILE ]]; then
+    echo "[WARN] Not enough permissions to write to $PICARD_CLI_FILE, trying sudo..."
+    cmd_prefix="sudo "
+  fi
+  bash -c "$cmd_prefix curl -o $PICARD_CLI_FILE $PICARD_CLI_URL --fail --silent --show-error && chmod +x $PICARD_CLI_FILE"
+}
+
+#
+# Main program
+#
+if [ ! -e $CIRCLECI_DIR ];
+then
+  mkdir -p $CIRCLECI_DIR >/dev/null
+fi
+
+case $1 in
+  # Option for development purpose only
+  --image | -i )
+    picard_image="$2"
+    shift; shift;
+    echo "[WARN] Using circleci:" $picard_image
+    ;;
+
+  --tag | -t )
+    picard_image="$PICARD_REPO:$2"
+    shift; shift;
+    echo "[WARN] Using circleci:" $picard_image
+esac
+
+# Do not check for update if --image of --tag is specified (to avoid overriding :latest tag)
+if [[ ! $picard_image ]]; then
+  current_digest=$(get_current_digest)
+  if [[ $current_digest == $UNKNOWN_DIGEST ]]; then
+    # Receiving latest image of picard in case of there's no current digest stored
+    echo "Receiving latest version of circleci..."
+    pull_latest_image >/dev/null
+    current_digest=$(get_latest_digest)
+    update_current_digest $current_digest
+  else
+    # Otherwise pulling latest image in background
+    pull_latest_image &>/dev/null &disown
+    echo
+  fi
+  picard_image="$PICARD_REPO@$current_digest"
+fi
+
+case $1 in
+  version )
+    print_cli_version
+    ;;
+
+  update )
+    echo "Updating CircleCI build agent..."
+    update_picard_cli
+    echo "Done"
+    echo "Updating CircleCI version..."
+    current_digest=$(get_latest_digest)
+    update_current_digest $current_digest
+    echo "Done"
+    exit 0
+    ;;
+
+  "" )
+    set -- "-h"
+esac
+
+if is_update_available; then
+  echo "INFO: There's a newer version of CircleCI build-agent available. Run 'circleci update' for update"
+fi
+
+# removed -t so it can be used without a tty
+docker run -i --rm \
+       -e DOCKER_API_VERSION=${DOCKER_API_VERSION:-1.23} \
+       -v /var/run/docker.sock:/var/run/docker.sock \
+       -v $(pwd):$(pwd) \
+       -v ~/.circleci/:/root/.circleci \
+       --workdir $(pwd) \
+       $picard_image \
+       circleci "$@"

--- a/scripts/validate-ci-config
+++ b/scripts/validate-ci-config
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+echo "Validating CircleCI config..."
+./scripts/circleci config validate

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,6 +2690,14 @@ jest-jasmine2@^21.2.1:
     jest-snapshot "^21.2.1"
     p-cancelable "^0.3.0"
 
+jest-junit@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-3.4.1.tgz#0f0aea65551290cabdf9a29a1681edb4eba418c5"
+  dependencies:
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-matcher-utils@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
@@ -4945,6 +4953,10 @@ xcode@^0.9.1:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
 
 xmlbuilder@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description
- eslint
- unit tests
- CircleCI test reports

## Motivation and Context
Running tests and other quality checks on every PR helps prevent bugs from sneaking into master.

Question: should we remove the unit tests and/or eslint from the pre-commit checks, since they're here now?
* Unit tests:
  * I lean towards yes, since I'm usually running `yarn test --watch` to autorun the tests as I make changes.
* eslint:
  * I also lean towards yes, since my editor highlights eslint errors - but sometimes I miss things anyway.
  * oddly, eslint seems to be the slower of the two (based on my anecdotal observations, anyway).

## How Has This Been Tested?
[Passing build workflow](https://circleci.com/workflow-run/33161a45-ab99-4d39-9377-d22b4c2eff4c)