### PR TITLE
Ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ buck-out/
 
 # Internal expo settings/state
 .expo
+
+
+# Visual Studio Code Files
+.vscode


### PR DESCRIPTION
## Description
Add .vscode to the .gitignore

## Motivation and Context
Files in the .vscode directory are better left configured per machine than checked into the repo