### PR TITLE
Implement event list card

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo": "^25.0.0",
     "lodash": "^4.17.4",
     "moment": "^2.20.1",
+    "moment-timezone": "^0.5.14",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.0",
     "react": "16.2.0",

--- a/src/components/EventListCard.js
+++ b/src/components/EventListCard.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, Text, StyleSheet } from 'react-native';
+
+import ListCard from './ListCard';
+import InteractionsCounter from './InteractionsCounter';
+import TextPill from './TextPill';
+
+import appPropTypes from '../propTypes';
+
+const styles = StyleSheet.create({
+  card: {
+    justifyContent: 'space-around',
+    height: 164,
+    padding: 20,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  metadataContainer: {
+    flex: 2,
+  },
+  counterContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  date: {
+    fontSize: 13,
+    color: '#9B9B9B',
+  },
+  location: {
+    fontSize: 13,
+    color: '#9B9B9B',
+  },
+  description: {
+    fontSize: 14,
+    color: '#9B9B9B',
+  },
+});
+
+function formatDate({ start, end, timezone }) {
+  if (!start) {
+    return '';
+  }
+
+  const startLocal = start.clone().tz(timezone);
+
+  const separator = ' • ';
+
+  if (!end) {
+    const strings = [startLocal.format('MMMM D, Y')];
+    if (startLocal.hour() !== 0) {
+      strings.push(startLocal.format('h:mm A'));
+    }
+    return strings.join(separator);
+  }
+
+  const endLocal = end.clone().tz(timezone);
+
+  if (startLocal.date() !== endLocal.date() &&
+      endLocal.diff(startLocal, 'hours') > 12) {
+    return `${startLocal.format('MMMM D')} - ${endLocal.date()}, ${startLocal.year()}`;
+  }
+
+  return [
+    startLocal.format('MMMM D, Y'),
+    `${startLocal.format('h:mm A')} - ${endLocal.format('h:mm A')}`,
+  ].join(separator);
+}
+
+const EventListCard = ({
+  style,
+  event,
+  isSearchResult,
+  ...props
+}) => (
+  <ListCard style={[styles.card, style]} {...props}>
+    {isSearchResult ? <TextPill>Event</TextPill> : null}
+    <View style={styles.header}>
+      <View style={styles.metadataContainer}>
+        <Text style={styles.title}>{event.title}</Text>
+        <Text style={styles.date}>{formatDate(event)}</Text>
+        <Text style={styles.location}>{event.location}</Text>
+      </View>
+      {isSearchResult ? null : (
+        <View style={styles.counterContainer}>
+          <InteractionsCounter />
+        </View>
+      )}
+    </View>
+    <Text style={styles.description} numberOfLines={isSearchResult ? 2 : 3}>
+      {event.description}
+    </Text>
+  </ListCard>
+);
+
+EventListCard.propTypes = {
+  style: View.propTypes.style,
+  event: appPropTypes.event.isRequired,
+  isSearchResult: PropTypes.bool,
+};
+
+EventListCard.defaultProps = {
+  style: {},
+  isSearchResult: false,
+};
+
+export default EventListCard;

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
+import moment from 'moment-timezone';
 
 const imageSource = PropTypes.shape({
   uri: PropTypes.string.isRequired,
@@ -57,5 +58,16 @@ export default {
     description: PropTypes.string.isRequired,
     duration: momentPropTypes.momentDurationObj,
     publishDate: momentPropTypes.momentObj,
+  }),
+  event: PropTypes.shape({
+    // TODO: expand as we use more of it
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    location: PropTypes.string.isRequired,
+    start: momentPropTypes.momentObj.isRequired,
+    end: momentPropTypes.momentObj,
+
+    // e.g. 'America/Detroit', 'Europe/Paris'
+    timezone: PropTypes.oneOf(moment.tz.names()).isRequired,
   }),
 };

--- a/storybook/stories/ListCard.stories.js
+++ b/storybook/stories/ListCard.stories.js
@@ -9,6 +9,7 @@ import PlayableListCard from '../../src/components/PlayableListCard';
 import PodcastEpisodeListCard from '../../src/components/PodcastEpisodeListCard';
 import LiturgyItemListCard from '../../src/components/LiturgyItemListCard';
 import MeditationListCard from '../../src/components/MeditationListCard';
+import EventListCard from '../../src/components/EventListCard';
 
 const styles = StyleSheet.create({
   card: {
@@ -176,6 +177,43 @@ const meditations = [
   },
 ];
 
+const events = [
+  {
+    title: 'The Liturgists Gathering',
+    start: moment('2017-10-27'),
+    end: moment('2017-10-28'),
+    location: 'Seattle, WA',
+    timezone: 'America/Los_Angeles',
+    description: (
+      'A place where the unlikely gather around a table and find a place to belong. ' +
+      'A safe place to have honest discussions about doubts, hopes, fears... and faith.'
+    ),
+  },
+  {
+    title: 'Ripple Effect Conference',
+    start: moment('2017-11-25'),
+    location: 'Lawrence, MA',
+    timezone: 'America/New_York',
+    description: (
+      'Ripple Effect is designed to provide resources that will inspire and ' +
+      'equip you and your leaders to live more fully into the mission of the ' +
+      'church. The planning team is at work now to provide a high-quality event ' +
+      'that includes...'
+    ),
+  },
+  {
+    title: 'Ask Science Mike LIVE',
+    start: moment('2018-02-07T18:00:00-08:00'),
+    location: 'Orange, CA',
+    timezone: 'America/Los_Angeles',
+    description: (
+      'Live at Chapman University, Science Mike will be taking questions and ' +
+      'giving answers right then and there. Ask Science Mike LIVE events are ' +
+      'always a lot of fun and...'
+    ),
+  },
+];
+
 
 storiesOf('List card', module)
   .add('Generic', () => <GenericListCards />)
@@ -201,10 +239,18 @@ storiesOf('List card', module)
       ))}
     </ScrollView>
   ))
+  .add('Events', () => (
+    <ScrollView>
+      {events.map(event => (
+        <EventListCard key={`${event.title}-${event.start}`} event={event} />
+      ))}
+    </ScrollView>
+  ))
   .add('Search results', () => (
     <ScrollView>
       <LiturgyItemListCard liturgyItem={liturgies[0]} isSearchResult />
       <PodcastEpisodeListCard podcastEpisode={podcasts[0]} isSearchResult />
       <MeditationListCard meditation={meditations[0]} isSearchResult />
+      <EventListCard event={events[0]} isSearchResult />
     </ScrollView>
   ));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,12 +3121,6 @@ doctrine@^2.0.2, doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-doctrine@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
-  dependencies:
-    esutils "^2.0.2"
-
 dom-converter@~0.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
@@ -6230,7 +6224,13 @@ mkpath@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/mkpath/-/mkpath-0.1.0.tgz#7554a6f8d871834cc97b5462b122c4c124d6de91"
 
-moment@2.x.x, moment@>=1.6.0, moment@^2.10.6, moment@^2.20.1:
+moment-timezone@^0.5.14:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.14.tgz#4eb38ff9538b80108ba467a458f3ed4268ccfcb1"
+  dependencies:
+    moment ">= 2.9.0"
+
+moment@2.x.x, "moment@>= 2.9.0", moment@>=1.6.0, moment@^2.10.6, moment@^2.20.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 


### PR DESCRIPTION
Closes #54.

Note: this PR defines a couple new details about events, which will soon be added to the app spec:

1. Event times are always displayed in the event's timezone.
2. The event model now has a `timezone` field, which is the [tz database timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones); e.g. `America/Detroit`, `Europe/Paris`.

This allows timezone localization that respects Daylight Savings Time (moment-timezone takes care of this for us), which would be more complicated if instead the timezone was simply a fixed UTC offset.

For discussion: @kbitgood mentioned that the time zone abbreviation should be displayed as well. Seems fine to me, but since that wasn't in the designs, I hereby ping @tannerhearne to weigh in. 🙂 

## Screenshots
<img width="913" alt="normal" src="https://user-images.githubusercontent.com/91550/36649978-c6e127b8-1a6e-11e8-9a19-dd024f87f206.png">
<img width="920" alt="search" src="https://user-images.githubusercontent.com/91550/36649977-c6d23b4a-1a6e-11e8-9aa1-643d7a6699ae.png">