### PR TITLE
Style the navigation tab bar

### DIFF
--- a/src/navigation/MainNavigator.js
+++ b/src/navigation/MainNavigator.js
@@ -20,6 +20,32 @@ const Tabs = TabNavigator({
   Home: { screen: HomeScreen },
   Podcasts: { screen: PodcastsScreen },
   Meditations: { screen: MeditationsScreen },
+}, {
+  ...TabNavigator.Presets.iOSBottomTabs,
+  tabBarOptions: {
+    activeTintColor: '#F95A57',
+    inactiveTintColor: '#D2D2D2',
+    style: {
+      borderTopWidth: 0,
+      padding: 5,
+
+      ...Platform.select({
+        ios: {
+          shadowColor: '#000',
+          shadowOpacity: 0.11,
+          shadowOffset: { width: 0, height: -3 },
+          shadowRadius: 21,
+        },
+        android: {
+          elevation: 100,
+          zIndex: 100,
+        },
+      }),
+    },
+    labelStyle: {
+      fontWeight: '600',
+    },
+  },
 });
 
 // hack to get the header to appear (it doesn't with a TabNavigator)

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
+import Icon from '@expo/vector-icons/Ionicons';
 
 import { getCommonNavigationOptions } from '../navigation/common';
 import styles from '../styles';
@@ -16,9 +18,24 @@ const HomeScreen = () => (
   </View>
 );
 
+const HomeIcon = ({ tintColor }) => (
+  <Icon
+    name="md-home"
+    style={{
+      color: tintColor,
+      fontSize: 32,
+    }}
+  />
+);
+
+HomeIcon.propTypes = {
+  tintColor: PropTypes.string.isRequired,
+};
+
 HomeScreen.navigationOptions = ({ screenProps }) => ({
   ...getCommonNavigationOptions(screenProps.drawer),
   title: 'Home',
+  tabBarIcon: HomeIcon,
 });
 
 export default HomeScreen;

--- a/src/screens/MeditationsScreen.js
+++ b/src/screens/MeditationsScreen.js
@@ -2,11 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Text, View } from 'react-native';
+import Icon from '@expo/vector-icons/Ionicons';
 
 import { getCommonNavigationOptions } from '../navigation/common';
 import * as patreonSelectors from '../state/ducks/patreon/selectors';
 import styles from '../styles';
 
+const MeditationsIcon = ({ tintColor }) => (
+  <Icon
+    name="md-sunny"
+    style={{
+      color: tintColor,
+      fontSize: 24,
+    }}
+  />
+);
+
+MeditationsIcon.propTypes = {
+  tintColor: PropTypes.string.isRequired,
+};
 /**
  * List of available meditations, organized by category.
  */
@@ -39,6 +53,7 @@ function mapStateToProps(state) {
 MeditationsScreen.navigationOptions = ({ screenProps }) => ({
   ...getCommonNavigationOptions(screenProps.drawer),
   title: 'Meditations',
+  tabBarIcon: MeditationsIcon,
 });
 
 export default connect(mapStateToProps)(MeditationsScreen);

--- a/src/screens/PodcastsScreen.js
+++ b/src/screens/PodcastsScreen.js
@@ -2,10 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
 import { connect } from 'react-redux';
+import Icon from '@expo/vector-icons/Entypo';
 
 import { getCommonNavigationOptions } from '../navigation/common';
 import * as patreonSelectors from '../state/ducks/patreon/selectors';
 import styles from '../styles';
+
+const PodcastsIcon = ({ tintColor }) => (
+  <Icon
+    name="rss"
+    style={{
+      color: tintColor,
+      fontSize: 32,
+    }}
+  />
+);
+
+PodcastsIcon.propTypes = {
+  tintColor: PropTypes.string.isRequired,
+};
 
 /**
  * List of available podcasts.
@@ -33,6 +48,7 @@ PodcastsScreen.propTypes = {
 PodcastsScreen.navigationOptions = ({ screenProps }) => ({
   ...getCommonNavigationOptions(screenProps.drawer),
   title: 'Podcasts',
+  tabBarIcon: PodcastsIcon,
 });
 
 function mapStateToProps(state) {


### PR DESCRIPTION
## Description
- Picked some placeholder icons
- Added colors
- Tweaked margins
- Added drop shadow (iOS only, currently)
- Force bottom tab bar on Android

## Motivation and Context
Closes #61.

## How has this been tested?

Poked at it a bit on iOS and Android simulators. No tab bar shadow on Android, sadly. Also, the vertical spacing still seems a bit off. Letting this be rough for now.