### PR TITLE
Create small audio player bar

### DIFF
--- a/fakeapi/src/resources/meditations.js
+++ b/fakeapi/src/resources/meditations.js
@@ -26,7 +26,7 @@ factory.define('meditations', Object, {
   id: factory.sequence('meditations.id', n => `${n}`),
   type: 'meditations',
   title: () => (
-    factory.chance('sentence', { words: 3 })().slice(0, -1)
+    factory.chance('sentence', { words: _.random(3, 8) })().slice(0, -1)
   ),
   description: () => (
     _.times(3, () => (

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "pretest": "yarn generate-default-config",
     "preci:deploy": "yarn generate-default-config",
     "prestorybook": "rnstl",
-    "postinstall": "rndebugger-open --expo; ( cd node_modules/redux-orm-proptypes; npm i; make build )"
+    "postinstall": "rndebugger-open --expo"
   },
   "dependencies": {
     "@expo/vector-icons": "^8.0.0",
+    "@theliturgists/redux-orm-proptypes": "^0.1.1",
     "axios": "^0.18.0",
     "expo": "^31.0.4",
     "lodash": "^4.17.4",
@@ -45,7 +46,6 @@
     "redux-devtools-extension": "^2.13.2",
     "redux-observable": "^0.17.0",
     "redux-orm": "^0.11.0",
-    "redux-orm-proptypes": "https://github.com/theliturgists/redux-orm-proptypes.git",
     "rxjs": "^5.5.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-native-slider": "^0.11.0",
     "react-navigation": "^2.18.2",
     "react-navigation-redux-helpers": "^1.0.3",
+    "react-navigation-tabs": "^0.8.4",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",

--- a/src/Root.js
+++ b/src/Root.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import AppNavigator from './navigation/AppNavigator';
+import { setTopLevelNavigator } from './navigation/NavigationService';
 import configureStore from './state/store';
 
 /**
@@ -11,7 +12,9 @@ import configureStore from './state/store';
  */
 const Root = () => (
   <Provider store={configureStore()}>
-    <AppNavigator />
+    <AppNavigator
+      ref={navigator => setTopLevelNavigator(navigator)}
+    />
   </Provider>
 );
 

--- a/src/components/PlayerStrip.js
+++ b/src/components/PlayerStrip.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import { StyleSheet, View, Text, TouchableWithoutFeedback } from 'react-native';
+import { connect } from 'react-redux';
+import _ from 'lodash';
+
+import appPropTypes from '../propTypes';
+
+import SquareImage from '../components/SquareImage';
+import Controls from '../screens/PlayerScreen/Controls';
+import * as actions from '../state/ducks/playback/actions';
+import * as selectors from '../state/ducks/playback/selectors';
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 7,
+    flexDirection: 'row',
+    backgroundColor: '#fff',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  imageContaner: {
+    width: 10,
+    height: 10,
+  },
+  item: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
+  itemDescription: {
+    flex: 1,
+    marginVertical: 10,
+    marginLeft: 5,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  seriesTitle: {
+    marginTop: 5,
+    fontSize: 10,
+  },
+  controls: {
+    marginLeft: 'auto',
+  },
+  jumpButtonIconStyle: {
+
+  },
+  jumpButtonStyle: {
+
+  },
+  playButtonIconStyle: {
+    fontSize: 36,
+  },
+  pauseButtonIconStyle: {
+    marginTop: 4,
+    fontSize: 36,
+  },
+  playbackButtonStyle: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    margin: 0,
+  },
+});
+
+function getSeriesTitle(item) {
+  const group = ['category', 'podcast', 'liturgy'].find(g => _.has(item, g));
+  return _.isUndefined(group) ? null : item[group].title;
+}
+
+const PlayerStrip = ({ item, navigation: { navigate } }) => (
+  item ? (
+    <TouchableWithoutFeedback
+      onPress={() => navigate('PlayerWithHeader')}
+    >
+      <View style={styles.container}>
+        <View style={styles.item}>
+          <View style={styles.imageContainer}>
+            <SquareImage
+              source={{ uri: item.imageUrl }}
+              width={10}
+            />
+          </View>
+          <View style={styles.itemDescription}>
+            <Text style={styles.title} numberOfLines={1}>{item.title}</Text>
+            <Text style={styles.seriesTitle} numberOfLines={1}>{getSeriesTitle(item)}</Text>
+          </View>
+        </View>
+        <Controls
+          style={styles.controls}
+          jumpButtonStyle={styles.jumpButtonStyle}
+          jumpButtonIconStyle={styles.jumpButtonIconStyle}
+          playbackButtonStyle={styles.playbackButtonStyle}
+          playButtonIconStyle={styles.playButtonIconStyle}
+          pauseButtonIconStyle={styles.pauseButtonIconStyle}
+        />
+      </View>
+    </TouchableWithoutFeedback>
+  ) : null
+);
+
+
+PlayerStrip.propTypes = {
+  navigation: appPropTypes.navigation.isRequired,
+  item: appPropTypes.mediaItem,
+};
+
+PlayerStrip.defaultProps = {
+  item: null,
+};
+
+function mapStateToProps(state) {
+  return {
+    item: selectors.item(state),
+    isPaused: selectors.isPaused(state),
+  };
+}
+
+export default connect(mapStateToProps, actions)(PlayerStrip);

--- a/src/navigation/MainNavigator.js
+++ b/src/navigation/MainNavigator.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { Animated, StyleSheet, Dimensions, Platform } from 'react-native';
-import {
-  createStackNavigator,
-  createBottomTabNavigator,
-} from 'react-navigation';
+import { Animated, StyleSheet, Dimensions, Platform, View } from 'react-native';
+import { createStackNavigator } from 'react-navigation';
+import { createBottomTabNavigator, BottomTabBar } from 'react-navigation-tabs';
 import { connect } from 'react-redux';
 import DropdownAlert from 'react-native-dropdownalert';
 import { GestureHandler, LinearGradient } from 'expo';
@@ -14,6 +12,7 @@ import HomeScreen from '../screens/HomeScreen';
 import LoginScreen from '../screens/LoginScreen';
 import PatreonScreen from '../screens/PatreonScreen';
 import PlayerScreen from '../screens/PlayerScreen';
+import PlayerStrip from '../components/PlayerStrip';
 import PodcastsScreen from '../screens/PodcastsScreen';
 import MeditationsScreen from '../screens/MeditationsScreen';
 import MeditationsCategoryScreen from '../screens/MeditationsCategoryScreen';
@@ -33,11 +32,19 @@ MeditationsNavigator.navigationOptions = {
   tabBarIcon: MeditationsIcon,
 };
 
+const TabBar = props => (
+  <View>
+    <PlayerStrip navigation={props.navigation} />
+    <BottomTabBar {...props} />
+  </View>
+);
+
 const Tabs = createBottomTabNavigator({
   Home: { screen: HomeScreen },
   Podcasts: { screen: PodcastsScreen },
   Meditations: { screen: MeditationsNavigator },
 }, {
+  tabBarComponent: TabBar,
   tabBarOptions: {
     activeTintColor: '#F95A57',
     inactiveTintColor: '#D2D2D2',

--- a/src/navigation/NavigationService.js
+++ b/src/navigation/NavigationService.js
@@ -1,0 +1,18 @@
+// https://reactnavigation.org/docs/en/navigating-without-navigation-prop.html
+
+import { NavigationActions } from 'react-navigation';
+
+let _navigator;
+
+export function setTopLevelNavigator(navigatorRef) {
+  _navigator = navigatorRef;
+}
+
+export function navigate(routeName, params) {
+  _navigator.dispatch(
+    NavigationActions.navigate({
+      routeName,
+      params,
+    }),
+  );
+}

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -15,6 +15,10 @@ export default {
     navigate: PropTypes.func.isRequired,
   }),
 
+  iconStyle: PropTypes.shape({
+    fontSize: PropTypes.number,
+  }),
+
   mediaItem: PropTypes.oneOfType(
     // TODO: other models
     [Meditation].map(

--- a/src/screens/PlayerScreen/Controls.js
+++ b/src/screens/PlayerScreen/Controls.js
@@ -160,6 +160,7 @@ const Controls = ({
       style={jumpButtonStyle}
       iconStyle={jumpButtonIconStyle}
       jumpSeconds={-jumpSeconds}
+      disabled={!item}
     />
     <PlaybackButton
       style={playbackButtonStyle}
@@ -167,17 +168,19 @@ const Controls = ({
       pauseButtonIconStyle={pauseButtonIconStyle}
       isPaused={isPaused}
       onPress={() => (isPaused ? play(item) : pause(item))}
+      disabled={!item}
     />
     <JumpButton
       style={jumpButtonStyle}
       iconStyle={jumpButtonIconStyle}
       jumpSeconds={jumpSeconds}
+      disabled={!item}
     />
   </View>
 );
 
 Controls.propTypes = {
-  item: appPropTypes.mediaItem.isRequired,
+  item: appPropTypes.mediaItem,
   isPaused: PropTypes.bool.isRequired,
   play: PropTypes.func.isRequired,
   pause: PropTypes.func.isRequired,
@@ -190,6 +193,7 @@ Controls.propTypes = {
 };
 
 Controls.defaultProps = {
+  item: null,
   style: {},
   jumpButtonStyle: {},
   jumpButtonIconStyle: {},

--- a/src/screens/PlayerScreen/Controls.js
+++ b/src/screens/PlayerScreen/Controls.js
@@ -1,0 +1,208 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import {
+  StyleSheet,
+  TouchableWithoutFeedback,
+  Text,
+  View,
+  ViewPropTypes,
+} from 'react-native';
+import { MaterialIcons, Foundation, AntDesign } from '@expo/vector-icons';
+
+import appPropTypes from '../../propTypes';
+
+import * as actions from '../../state/ducks/playback/actions';
+import * as selectors from '../../state/ducks/playback/selectors';
+
+const styles = StyleSheet.create({
+  controls: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  playbackButton: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    borderColor: '#000',
+    borderWidth: 2,
+    margin: 10,
+  },
+  playIcon: {
+    paddingTop: 4,
+    paddingLeft: 2,
+    fontSize: 48,
+  },
+  pauseIcon: {
+    fontSize: 48,
+  },
+  jumpIconContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  jumpIcon: {
+    fontSize: 56,
+  },
+  jumpIconText: {
+    position: 'absolute',
+    fontSize: 12,
+    bottom: 17,
+    backgroundColor: '#fff',
+  },
+});
+
+const PlaybackButton = ({
+  isPaused,
+  onPress,
+  style,
+  playButtonIconStyle,
+  pauseButtonIconStyle,
+}) => (
+  <TouchableWithoutFeedback onPress={onPress}>
+    <View style={[styles.playbackButton, style]}>
+      {
+        isPaused
+          ? <Foundation name="play" style={[styles.playIcon, playButtonIconStyle]} />
+          : <AntDesign name="pause" style={[styles.pauseIcon, pauseButtonIconStyle]} />
+      }
+    </View>
+  </TouchableWithoutFeedback>
+);
+
+PlaybackButton.propTypes = {
+  isPaused: PropTypes.bool.isRequired,
+  onPress: PropTypes.func.isRequired,
+  style: ViewPropTypes.style,
+  playButtonIconStyle: appPropTypes.iconStyle,
+  pauseButtonIconStyle: appPropTypes.iconStyle,
+};
+
+PlaybackButton.defaultProps = {
+  style: {},
+  playButtonIconStyle: {},
+  pauseButtonIconStyle: {},
+};
+
+const JumpIcon = ({
+  jumpSeconds,
+  style,
+}) => (
+  <View style={[styles.jumpIconContainer, style]}>
+    <MaterialIcons
+      style={styles.jumpIcon}
+      name={`${jumpSeconds > 0 ? 'forward-5' : 'replay'}`}
+    />
+    <Text
+      style={[
+        styles.jumpIconText,
+      ]}
+    >
+      {Math.abs(jumpSeconds)}
+    </Text>
+  </View>
+);
+
+JumpIcon.propTypes = {
+  style: ViewPropTypes.style,
+  jumpSeconds: PropTypes.number.isRequired,
+};
+
+JumpIcon.defaultProps = {
+  style: {},
+};
+
+let JumpButton = ({
+  jumpSeconds,
+  jump,
+  iconStyle,
+}) => (
+  <TouchableWithoutFeedback
+    onPress={() => { jump(jumpSeconds); }}
+  >
+    <View>
+      <JumpIcon style={iconStyle} jumpSeconds={jumpSeconds} />
+    </View>
+  </TouchableWithoutFeedback>
+);
+
+JumpButton.propTypes = {
+  jumpSeconds: PropTypes.number.isRequired,
+  jump: PropTypes.func.isRequired,
+  iconStyle: appPropTypes.iconStyle,
+};
+
+JumpButton.defaultProps = {
+  iconStyle: {},
+};
+
+JumpButton = connect(null, actions)(JumpButton);
+
+const jumpSeconds = 30;
+
+
+const Controls = ({
+  item,
+  isPaused,
+  play,
+  pause,
+  style,
+  jumpButtonStyle,
+  jumpButtonIconStyle,
+  playbackButtonStyle,
+  playButtonIconStyle,
+  pauseButtonIconStyle,
+}) => (
+  <View style={[styles.controls, style]}>
+    <JumpButton
+      style={jumpButtonStyle}
+      iconStyle={jumpButtonIconStyle}
+      jumpSeconds={-jumpSeconds}
+    />
+    <PlaybackButton
+      style={playbackButtonStyle}
+      playButtonIconStyle={playButtonIconStyle}
+      pauseButtonIconStyle={pauseButtonIconStyle}
+      isPaused={isPaused}
+      onPress={() => (isPaused ? play(item) : pause(item))}
+    />
+    <JumpButton
+      style={jumpButtonStyle}
+      iconStyle={jumpButtonIconStyle}
+      jumpSeconds={jumpSeconds}
+    />
+  </View>
+);
+
+Controls.propTypes = {
+  item: appPropTypes.mediaItem.isRequired,
+  isPaused: PropTypes.bool.isRequired,
+  play: PropTypes.func.isRequired,
+  pause: PropTypes.func.isRequired,
+  style: ViewPropTypes.style,
+  jumpButtonStyle: ViewPropTypes.style,
+  playbackButtonStyle: ViewPropTypes.style,
+  jumpButtonIconStyle: appPropTypes.iconStyle,
+  playButtonIconStyle: appPropTypes.iconStyle,
+  pauseButtonIconStyle: appPropTypes.iconStyle,
+};
+
+Controls.defaultProps = {
+  style: {},
+  jumpButtonStyle: {},
+  jumpButtonIconStyle: {},
+  playbackButtonStyle: {},
+  playButtonIconStyle: {},
+  pauseButtonIconStyle: {},
+};
+
+function mapStateToProps(state) {
+  return {
+    item: selectors.item(state),
+    isPaused: selectors.isPaused(state),
+  };
+}
+
+export default connect(mapStateToProps, actions)(Controls);

--- a/src/screens/PlayerScreen/index.js
+++ b/src/screens/PlayerScreen/index.js
@@ -68,9 +68,10 @@ function getSeriesTitle(item) {
 }
 
 class PlayerScreen extends React.Component {
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    const { item: prevItem } = prevProps;
     const { navigation, item } = this.props;
-    if (!item) {
+    if (prevItem && !item) {
       navigation.goBack(null);
     }
   }

--- a/src/screens/PlayerScreen/index.js
+++ b/src/screens/PlayerScreen/index.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { Platform, Text, View, StyleSheet, TouchableWithoutFeedback } from 'react-native';
+import { Platform, Text, View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 
-import { MaterialIcons, FontAwesome, Foundation, AntDesign } from '@expo/vector-icons';
+import { FontAwesome } from '@expo/vector-icons';
 
 import SquareImage from '../../components/SquareImage';
 import { screenRelativeWidth } from '../../components/utils';
@@ -14,6 +13,7 @@ import * as selectors from '../../state/ducks/playback/selectors';
 import appStyles from '../../styles';
 
 import AudioTimeline from './AudioTimeline';
+import Controls from './Controls';
 
 const shadowRadius = 6;
 
@@ -59,40 +59,6 @@ const styles = StyleSheet.create({
   },
   controls: {
     marginTop: 20,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  playbackButton: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    borderColor: '#000',
-    borderWidth: 2,
-    margin: 10,
-  },
-  playIcon: {
-    paddingTop: 4,
-    paddingLeft: 2,
-    fontSize: 48,
-  },
-  pauseIcon: {
-    fontSize: 48,
-  },
-  jumpIconContainer: {
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  jumpIcon: {
-    fontSize: 56,
-  },
-  jumpIconText: {
-    position: 'absolute',
-    fontSize: 12,
-    bottom: 17,
-    backgroundColor: '#fff',
   },
 });
 
@@ -101,101 +67,43 @@ function getSeriesTitle(item) {
   return _.isUndefined(group) ? null : item[group].title;
 }
 
-const PlaybackButton = ({ isPaused, onPress }) => (
-  <TouchableWithoutFeedback onPress={onPress}>
-    <View style={styles.playbackButton}>
-      {
-        isPaused
-          ? <Foundation name="play" style={styles.playIcon} />
-          : <AntDesign name="pause" style={styles.pauseIcon} />
-      }
-    </View>
-  </TouchableWithoutFeedback>
-);
+class PlayerScreen extends React.Component {
+  componentDidUpdate() {
+    const { navigation, item } = this.props;
+    if (!item) {
+      navigation.goBack(null);
+    }
+  }
 
-PlaybackButton.propTypes = {
-  isPaused: PropTypes.bool.isRequired,
-  onPress: PropTypes.func.isRequired,
-};
+  render() {
+    const { item } = this.props;
 
-const JumpIcon = ({
-  jumpSeconds,
-}) => (
-  <View style={styles.jumpIconContainer}>
-    <MaterialIcons
-      style={styles.jumpIcon}
-      name={`${jumpSeconds > 0 ? 'forward-5' : 'replay'}`}
-    />
-    <Text
-      style={[
-        styles.jumpIconText,
-      ]}
-    >
-      {Math.abs(jumpSeconds)}
-    </Text>
-  </View>
-);
+    if (!item) {
+      return null;
+    }
 
-JumpIcon.propTypes = {
-  jumpSeconds: PropTypes.number.isRequired,
-};
-
-let JumpButton = ({
-  jumpSeconds,
-  jump,
-}) => (
-  <TouchableWithoutFeedback
-    onPress={() => { jump(jumpSeconds); }}
-  >
-    <View>
-      <JumpIcon jumpSeconds={jumpSeconds} />
-    </View>
-  </TouchableWithoutFeedback>
-);
-
-JumpButton.propTypes = {
-  jumpSeconds: PropTypes.number.isRequired,
-  jump: PropTypes.func.isRequired,
-};
-
-JumpButton = connect(null, actions)(JumpButton);
-
-const jumpSeconds = 30;
-
-const PlayerScreen = ({
-  item,
-  isPaused,
-  play,
-  pause,
-}) => (
-  <View style={appStyles.container}>
-    <View style={styles.imageContainer}>
-      <SquareImage
-        source={{ uri: item.imageUrl }}
-        width={screenRelativeWidth(1)}
-      />
-    </View>
-    <View style={styles.mediaContainer}>
-      <Text style={styles.title}>{item.title}</Text>
-      <Text style={styles.seriesTitle}>{getSeriesTitle(item)}</Text>
-      <AudioTimeline style={styles.timeline} />
-      <View style={styles.controls}>
-        <JumpButton jumpSeconds={-jumpSeconds} />
-        <PlaybackButton
-          isPaused={isPaused}
-          onPress={() => (isPaused ? play(item) : pause(item))}
-        />
-        <JumpButton jumpSeconds={jumpSeconds} />
+    return (
+      <View style={appStyles.container}>
+        <View style={styles.imageContainer}>
+          <SquareImage
+            source={{ uri: item.imageUrl }}
+            width={screenRelativeWidth(1)}
+          />
+        </View>
+        <View style={styles.mediaContainer}>
+          <Text style={styles.title}>{item.title}</Text>
+          <Text style={styles.seriesTitle}>{getSeriesTitle(item)}</Text>
+          <AudioTimeline style={styles.timeline} />
+          <Controls style={styles.controls} />
+        </View>
       </View>
-    </View>
-  </View>
-);
+    );
+  }
+}
 
 PlayerScreen.propTypes = {
+  navigation: appPropTypes.navigation.isRequired,
   item: appPropTypes.mediaItem.isRequired,
-  isPaused: PropTypes.bool.isRequired,
-  play: PropTypes.func.isRequired,
-  pause: PropTypes.func.isRequired,
 };
 
 PlayerScreen.navigationOptions = ({ navigation }) => ({
@@ -212,9 +120,7 @@ PlayerScreen.navigationOptions = ({ navigation }) => ({
 function mapStateToProps(state) {
   return {
     item: selectors.item(state),
-    isPlaying: selectors.isPlaying(state),
     isPaused: selectors.isPaused(state),
-    elapsed: selectors.elapsed(state),
   };
 }
 

--- a/src/screens/PlayerScreen/index.js
+++ b/src/screens/PlayerScreen/index.js
@@ -78,20 +78,20 @@ class PlayerScreen extends React.Component {
   render() {
     const { item } = this.props;
 
-    if (!item) {
-      return null;
-    }
-
     return (
       <View style={appStyles.container}>
         <View style={styles.imageContainer}>
-          <SquareImage
-            source={{ uri: item.imageUrl }}
-            width={screenRelativeWidth(1)}
-          />
+          {
+            item ? (
+              <SquareImage
+                source={{ uri: item.imageUrl }}
+                width={screenRelativeWidth(1)}
+              />
+            ) : null
+          }
         </View>
         <View style={styles.mediaContainer}>
-          <Text style={styles.title}>{item.title}</Text>
+          <Text style={styles.title}>{item ? item.title : ''}</Text>
           <Text style={styles.seriesTitle}>{getSeriesTitle(item)}</Text>
           <AudioTimeline style={styles.timeline} />
           <Controls style={styles.controls} />
@@ -103,7 +103,11 @@ class PlayerScreen extends React.Component {
 
 PlayerScreen.propTypes = {
   navigation: appPropTypes.navigation.isRequired,
-  item: appPropTypes.mediaItem.isRequired,
+  item: appPropTypes.mediaItem,
+};
+
+PlayerScreen.defaultProps = {
+  item: null,
 };
 
 PlayerScreen.navigationOptions = ({ navigation }) => ({

--- a/src/state/ducks/playback/reducer.js
+++ b/src/state/ducks/playback/reducer.js
@@ -56,6 +56,7 @@ export default handleActions({
   [SET_STATUS]: (state, action) => ({
     ...state,
     status: action.payload,
+    item: action.payload.didJustFinish ? null : state.item,
   }),
   [SET_PENDING_SEEK]: (state, action) => ({
     ...state,

--- a/src/state/ducks/playback/selectors.js
+++ b/src/state/ducks/playback/selectors.js
@@ -4,6 +4,9 @@ import moment from 'moment';
 import { instanceSelector } from '../orm/selectors';
 
 export function item(state) {
+  if (!state.playback.item) {
+    return null;
+  }
   const { type, id } = state.playback.item;
   return instanceSelector(state, type, id);
 }

--- a/src/state/models/Contributor.js
+++ b/src/state/models/Contributor.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { attr, Model } from 'redux-orm';
-import propTypesMixin from 'redux-orm-proptypes';
+import propTypesMixin from '@theliturgists/redux-orm-proptypes';
 
 
 const ValidatingModel = propTypesMixin(Model);

--- a/src/state/models/Meditation.js
+++ b/src/state/models/Meditation.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { fk, many, attr, Model } from 'redux-orm';
-import propTypesMixin from 'redux-orm-proptypes';
+import propTypesMixin from '@theliturgists/redux-orm-proptypes';
 
 const ValidatingModel = propTypesMixin(Model);
 

--- a/src/state/models/MeditationCategory.js
+++ b/src/state/models/MeditationCategory.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { many, attr, Model } from 'redux-orm';
-import propTypesMixin from 'redux-orm-proptypes';
+import propTypesMixin from '@theliturgists/redux-orm-proptypes';
 
 const ValidatingModel = propTypesMixin(Model);
 

--- a/src/state/models/Tag.js
+++ b/src/state/models/Tag.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { attr, Model } from 'redux-orm';
-import propTypesMixin from 'redux-orm-proptypes';
+import propTypesMixin from '@theliturgists/redux-orm-proptypes';
 
 const ValidatingModel = propTypesMixin(Model);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9732,7 +9732,7 @@ react-navigation-stack@0.7.0:
   resolved "https://registry.yarnpkg.com/react-navigation-stack/-/react-navigation-stack-0.7.0.tgz#0b2f139ee1cba953037ef51353df992ec6c74fa2"
   integrity sha512-3Tbb/SsustBrM9R/qaI6XuOfyqYMVbwkeHFC8NbU890vB0aKZvjAtioWLZ18e/4LgbiOCmoTdp37z3gkGDyNDQ==
 
-react-navigation-tabs@0.8.4:
+react-navigation-tabs@0.8.4, react-navigation-tabs@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/react-navigation-tabs/-/react-navigation-tabs-0.8.4.tgz#aa767f28b899f13c99f2b034b4a665f8cf0a5737"
   integrity sha512-CbS3xIVJVtpu+AYslv0PMLmjddJFVtU3XAhSJ9XnMrKLUJNmnQdW/L0w/Gp5qcBEF9h6bgsY3CoTtp7I6bqyOQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,6 +887,13 @@
     react-split-pane "^0.1.77"
     react-treebeard "^2.1.0"
 
+"@theliturgists/redux-orm-proptypes@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@theliturgists/redux-orm-proptypes/-/redux-orm-proptypes-0.1.1.tgz#db645baacc2c190f12a806e8bddc8e5871ac48d8"
+  integrity sha512-snnXSVfFNJPglms3JhuVmAY8OvclBz4TYsqcfkXn7SmLwH9sjgzTqt1sfhiAYWzNi2PZyZjAq+MSvSUAemlX7A==
+  dependencies:
+    prop-types "^15.6.0"
+
 "@types/fbemitter@^2.0.32":
   version "2.0.32"
   resolved "https://registry.yarnpkg.com/@types/fbemitter/-/fbemitter-2.0.32.tgz#8ed204da0f54e9c8eaec31b1eec91e25132d082c"
@@ -10008,12 +10015,6 @@ redux-observable@^0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.17.0.tgz#23e29e3f3c39204b7ed6a14b67a29e317c03106b"
   integrity sha512-nVRl9KxdDNLKQRBkQK/svQIYDgTTDJbn3DEG6JB/DauZQs9bYl6R7b6ospXAS1zs6THarWHd3BhTTnGXFybVdA==
-
-"redux-orm-proptypes@https://github.com/theliturgists/redux-orm-proptypes.git":
-  version "0.1.0"
-  resolved "https://github.com/theliturgists/redux-orm-proptypes.git#e8afa94e01cf432896e7a2e50ca8ffa92253b64e"
-  dependencies:
-    prop-types "^15.6.0"
 
 redux-orm@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
## Description
Added a player bar with:
- Item artwork thumbnail
- Item and series titles
- Play/pause
- Skip forward back 30 sec

Behaviors:
- Appears on all screens with the tab bar
- Disappears when playback finishes
- Opens player screen on tap

Known issues:
- Styling is rough. Very open to feedback here.
- ~~On player screen, playback finishing goes back to initial route, not previous screen~~
  - Fixed, along with related propTypes warnings.

## Motivation and Context
Closes #91.

## How Has This Been Tested?
- Played several different meditations. Controls work; all seems copasetic.

## Screenshots (if appropriate):
![playerbar](https://user-images.githubusercontent.com/91550/49382762-3f047300-f6e5-11e8-8eef-ff6e2c9ee096.png)
