### PR TITLE
Deploy master to default expo channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,25 +114,16 @@ workflows:
           context: global
           requires:
             - install_fakeapi_dependencies
-          filters:
-            branches:
-              ignore: master
       - deploy-app:
           context: global
           requires:
             - install_dependencies
             - unit_tests
-          filters:
-            branches:
-              ignore: master
       - deploy-storybook:
           context: global
           requires:
             - install_dependencies
             - unit_tests
-          filters:
-            branches:
-              ignore: master
       - report-deploy-to-pr:
           context: global
           requires:

--- a/ci/deploy-to-expo.sh
+++ b/ci/deploy-to-expo.sh
@@ -9,7 +9,7 @@ get_now_alias() {
 yarn global add exp
 
 fail=
-for name in EXPO_USERNAME EXPO_PASSWORD CIRCLE_SHA1 ; do
+for name in EXPO_USERNAME EXPO_PASSWORD CIRCLE_BRANCH ; do
   eval value=\$$name
   if [[ -z ${value} ]]; then
     echo >&2 "Missing required env variable: ${name}"
@@ -30,4 +30,8 @@ prefix=
 if [[ "$1" == "storybook" ]]; then
   prefix="storybook-"
 fi
-exp publish --release-channel "${prefix}${CIRCLE_SHA1}"
+channel=${CIRCLE_BRANCH}
+if [[ "${channel}" == "master" ]]; then
+  channel="default"
+fi
+exp publish --release-channel "${prefix}${channel}"


### PR DESCRIPTION
## Description
- Use branch, rather than commit, as expo release channel
- Use `default` release channel when deploying master
- Enable deploys (app, storybook, fakeapi) from master

## Motivation and Context
We want to be able to demo and review the app as it exists on master, on devices. Anyone who can log in to "theliturgists" expo account can run the app on their device. (Expo will support organizations in the (near?) future; until then, ping @brettdh for credentials.)

## How Has This Been Tested?
It's about to be, after this PR is merged (since the master behavior is different).