### PR TITLE
Fix error display and Patreon refreshing

### DIFF
--- a/src/navigation/DrawerContent.js
+++ b/src/navigation/DrawerContent.js
@@ -4,14 +4,16 @@ import {
   Image,
   StyleSheet,
 } from 'react-native';
+import { connect } from 'react-redux';
 import { withNavigation } from 'react-navigation';
 import { LinearGradient } from 'expo';
 
 import DrawerItem from './DrawerItem';
 import PatreonStatus from './PatreonStatus';
 
+import * as patreon from '../state/ducks/patreon/actions';
+
 import patreonIcon from '../../assets/patreon_icon.png';
-import appPropTypes from '../propTypes';
 
 const styles = StyleSheet.create({
   drawer: {
@@ -33,7 +35,7 @@ const styles = StyleSheet.create({
 
 const DrawerContent = ({
   drawer,
-  navigation,
+  navigateToPatreon,
 }) => (
   <LinearGradient style={styles.drawer} colors={['#FFFFFF00', '#F95A570C']}>
     <PatreonStatus />
@@ -41,18 +43,29 @@ const DrawerContent = ({
       drawer={drawer}
       image={<Image source={patreonIcon} style={styles.patreonImage} />}
       title="Manage Patreon"
-      onPress={() => navigation.navigate('Patreon')}
+      onPress={navigateToPatreon}
     />
   </LinearGradient>
 );
 
 DrawerContent.propTypes = {
   drawer: PropTypes.shape({}),
-  navigation: appPropTypes.navigation.isRequired,
+  navigateToPatreon: PropTypes.func.isRequired,
 };
 
 DrawerContent.defaultProps = {
   drawer: {},
 };
 
-export default withNavigation(DrawerContent);
+function mapDispatchToProps(dispatch, { navigation }) {
+  return {
+    navigateToPatreon: () => {
+      dispatch(patreon.getDetails());
+      navigation.navigate('Patreon');
+    },
+  };
+}
+
+export default withNavigation(
+  connect(null, mapDispatchToProps)(DrawerContent),
+);

--- a/src/navigation/MainNavigator.js
+++ b/src/navigation/MainNavigator.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 import { Animated, StyleSheet, Dimensions, Platform, View } from 'react-native';
 import { createStackNavigator } from 'react-navigation';
 import { createBottomTabNavigator, BottomTabBar } from 'react-navigation-tabs';
-import { connect } from 'react-redux';
 import DropdownAlert from 'react-native-dropdownalert';
 import { GestureHandler, LinearGradient } from 'expo';
 
@@ -22,6 +20,8 @@ import DrawerContent from '../navigation/DrawerContent';
 import MeditationsIcon from '../screens/MeditationsIcon';
 import PodcastsIcon from '../screens/PodcastsIcon';
 import HomeIcon from '../screens/HomeIcon';
+
+import { setDropdown } from '../showError';
 
 const { DrawerLayout } = GestureHandler;
 
@@ -144,7 +144,6 @@ class MainNavigator extends React.Component {
     this.state = {
       drawer: null,
     };
-    this.dropDown = null;
   }
 
   getAnimatedStyles(progressValue) {
@@ -166,18 +165,6 @@ class MainNavigator extends React.Component {
   }
 
   render() {
-    const { apiError } = this.props;
-    if (apiError && this.dropDown) {
-      this.dropDown.alertWithType(
-        'error',
-        apiError.message || 'Error',
-        [
-          `URL: ${apiError.config.url}`,
-          _.get(apiError, 'request._response', ''),
-        ].join('\n'),
-      );
-    }
-
     return (
       <LinearGradient style={styles.gradient} colors={['#FFFFFF00', '#F95A570C']}>
         <DrawerLayout
@@ -205,8 +192,10 @@ class MainNavigator extends React.Component {
                   navigation={this.props.navigation}
                 />
                 <DropdownAlert
-                  ref={(ref) => { this.dropDown = ref; }}
+                  ref={(ref) => { setDropdown(ref); }}
                   messageNumOfLines={10}
+                  closeInterval={null}
+                  showCancel
                 />
               </Animated.View>
             )
@@ -227,14 +216,4 @@ MainNavigator.defaultProps = {
   apiError: null,
 };
 
-function mapStateToProps(state) {
-  return {
-    apiError: _.get(
-      state,
-      'orm.api.error',
-      _.get(state, 'patreon.error'),
-    ),
-  };
-}
-
-export default connect(mapStateToProps)(MainNavigator);
+export default MainNavigator;

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -19,6 +19,7 @@ import patreonBackground from '../../assets/patreon_bg.png';
 
 import * as actions from '../state/ducks/patreon/actions';
 import * as selectors from '../state/ducks/patreon/selectors';
+import * as constants from '../state/ducks/patreon/constants';
 import appStyles from '../styles';
 
 const styles = StyleSheet.create({
@@ -256,8 +257,13 @@ const PatreonManageButton = ({ isConnected, pledge, getDetails }) => (
     <PatreonButton
       title="Manage Your Pledge"
       onPress={() => {
+        const pledgeSlug = _.get(
+          pledge,
+          'reward.campaign.pledge_url',
+          constants.PLEDGE_SLUG,
+        );
         const pledgeUrl =
-          `https://www.patreon.com/${pledge.reward.campaign.pledge_url}`;
+          `${constants.BASE_URL}/${pledgeSlug}`;
         WebBrowser.openAuthSessionAsync(pledgeUrl)
           .then(() => getDetails());
       }}

--- a/src/showError.js
+++ b/src/showError.js
@@ -1,0 +1,22 @@
+import _ from 'lodash';
+
+let dropdown;
+
+export function setDropdown(d) {
+  dropdown = d;
+}
+
+export default function showError(error) {
+  if (!dropdown) {
+    return;
+  }
+
+  dropdown.alertWithType(
+    'error',
+    error.message || 'Error',
+    [
+      `URL: ${error.config.url}`,
+      _.get(error, 'request._response', ''),
+    ].join('\n'),
+  );
+}

--- a/src/state/ducks/orm/epic.js
+++ b/src/state/ducks/orm/epic.js
@@ -21,6 +21,7 @@ import { singular } from 'pluralize';
 import { FETCH_DATA } from './types';
 import { receiveData, receiveApiError } from './actions';
 import config from '../../../../config.json';
+import showError from '../../../showError';
 
 /**
  * Fetch API data.
@@ -59,10 +60,15 @@ const fetchDataEpic = (action$) => {
           ..._.pick(action.payload, ['resource', 'id']),
           json,
         }))
-        .catch(error => Observable.of(receiveApiError({
-          ..._.pick(action.payload, ['resource', 'id']),
-          error,
-        })))
+        .catch((error) => {
+          showError(error);
+          return Observable.of(
+            receiveApiError({
+              ..._.pick(action.payload, ['resource', 'id']),
+              error,
+            }),
+          );
+        })
     ));
 };
 

--- a/src/state/ducks/patreon/constants.js
+++ b/src/state/ducks/patreon/constants.js
@@ -1,0 +1,5 @@
+export const BASE_URL = 'https://www.patreon.com';
+export const CAMPAIGN_SLUG = 'bdhtest';
+export const CAMPAIGN_URL = `${BASE_URL}/${CAMPAIGN_SLUG}`;
+export const PLEDGE_SLUG = `join/${CAMPAIGN_SLUG}`;
+export const PLEDGE_URL = `${BASE_URL}/${PLEDGE_SLUG}`;

--- a/src/state/ducks/patreon/epic.js
+++ b/src/state/ducks/patreon/epic.js
@@ -25,6 +25,7 @@ import config from '../../../../config.json';
 import { CONNECT, GET_DETAILS } from './types';
 import * as actions from './actions';
 import * as selectors from './selectors';
+import showError from '../../../showError';
 
 function generateCsrfToken() {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
@@ -100,9 +101,10 @@ function getPatreonDetails(token) {
 }
 
 function catchApiError() {
-  return catchError(e => (
-    Observable.of(actions.storeError(e))
-  ));
+  return catchError((e) => {
+    showError(e);
+    return Observable.of(actions.storeError(e));
+  });
 }
 
 /**


### PR DESCRIPTION
A couple bug fixes:
- Make error dropdown invocation procedural, not on every render
  - This avoids re-displaying the error every time the user navigates
  - It also works around an apparent bug (or usage confusion) with redux-persist, wherein the key blacklist doesn't seem to be working
- Refresh Patreon details every time user navigates to PatreonScreen
  - If there is a transient error with the Patreon API, this ensures that the details fetch gets retried
  - Also ensures the info is refreshed if the user edits their pledge outside the app
- Fix bug wherein the app crashed if you connected Patreon as a non-patron and tapped "Manage My Pledge"
  - If it's available, we look up the pledge URL from the details from the Patreon API. If not, we use a constant fallback. (We should maybe just always use the constant.)