### PR TITLE
Filter content by Patreon pledge level

### DIFF
--- a/ci/deploy-to-expo.sh
+++ b/ci/deploy-to-expo.sh
@@ -3,7 +3,7 @@
 yarn global add exp
 
 fail=
-for name in EXPO_USERNAME EXPO_PASSWORD CIRCLE_BRANCH PATREON_CLIENT_ID CONTENTFUL_SANDBOX_SPACE CONTENTFUL_SANDBOX_ENVIRONMENT CONTENTFUL_SANDBOX_ACCESS_TOKEN ; do
+for name in EXPO_USERNAME EXPO_PASSWORD CIRCLE_BRANCH PATREON_CLIENT_ID ; do
   eval value=\$$name
   if [[ -z ${value} ]]; then
     echo >&2 "Missing required env variable: ${name}"
@@ -15,19 +15,10 @@ if [[ -n $fail ]]; then
   exit 1
 fi
 
-# XXX: clever folk will be able to retrieve this access token and gain
-# read-only access to anything in the space. That's fine; we won't put anything
-# sensitive there. Once we go live with our real API, we will revoke this token
-# and use a different one that only the API backend knows about.
 api_url="https://staging.api.theliturgists.com"
 json -I -f config.json \
   -e "this.apiBaseUrl='${api_url}'" \
   -e "this.patreonClientId='${PATREON_CLIENT_ID}'" \
-  -e "this.contentful={
-    space: '${CONTENTFUL_SANDBOX_SPACE}',
-    environment: '${CONTENTFUL_SANDBOX_ENVIRONMENT}',
-    accessToken: '${CONTENTFUL_SANDBOX_ACCESS_TOKEN}'
-  }"
 
 exp login -u "${EXPO_USERNAME}" -p "${EXPO_PASSWORD}"
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@expo/vector-icons": "^8.0.0",
     "@theliturgists/redux-orm-proptypes": "^0.1.1",
     "axios": "^0.18.0",
+    "axios-retry": "^3.1.2",
     "contentful": "^7.1.0",
     "expo": "^31.0.4",
     "jsonapi-datastore": "^0.4.0-beta",
@@ -52,7 +53,8 @@
     "redux-orm": "^0.11.0",
     "redux-persist": "^5.10.0",
     "redux-persist-expo-securestore": "^0.1.1",
-    "rxjs": "^5.5.6"
+    "rxjs": "^5.5.6",
+    "url-parse": "^1.4.4"
   },
   "devDependencies": {
     "@octokit/rest": "^15.2.3",

--- a/src/components/PodcastSeriesTile.js
+++ b/src/components/PodcastSeriesTile.js
@@ -14,14 +14,14 @@ const formatEpisodeCount = (episodeCount) => {
   return `${episodeCount} ${episodeString}`;
 };
 
-const formatPodcastDescription = (episodeCount, lastUpdated) => {
+const formatPodcastDescription = (episodeCount, latestEpisode) => {
   const separator = ' • ';
   const strings = [];
   if (!_.isNull(episodeCount)) {
     strings.push(formatEpisodeCount(episodeCount));
   }
-  if (!_.isNull(lastUpdated)) {
-    strings.push(moment(lastUpdated).fromNow());
+  if (!_.isNull(latestEpisode)) {
+    strings.push(moment(latestEpisode.publishedAt).fromNow());
   }
   return strings.join(separator);
 };
@@ -31,7 +31,10 @@ const PodcastSeriesTile = ({ podcast, onPress }) => (
     imageUrl={podcast.imageUrl}
     title={podcast.title}
     onPress={() => onPress(podcast)}
-    description={formatPodcastDescription(podcast.episodes.length, podcast.updatedAt)}
+    description={formatPodcastDescription(
+      podcast.episodes.length,
+      _.get(podcast.episodes, 0, null),
+    )}
   />
 );
 

--- a/src/screens/MeditationsCategoryScreen.js
+++ b/src/screens/MeditationsCategoryScreen.js
@@ -74,18 +74,19 @@ function mapDispatchToProps(dispatch, { navigation }) {
 
   return {
     refreshCategory: () => {
-      let action;
-      if (category.title === 'All Meditations') {
-        action = fetchData({
-          resource: 'meditations',
-        });
-      } else {
-        action = fetchData({
+      let collection;
+      if (category.title !== 'All Meditations') {
+        collection = {
+          field: 'category',
           id: category.id,
-          // TODO: ensure related meditations are also fetched/updated?
-        });
+        };
       }
-      dispatch(action);
+      dispatch(
+        fetchData({
+          resource: 'meditations',
+          collection,
+        }),
+      );
     },
   };
 }

--- a/src/screens/MeditationsCategoryScreen.js
+++ b/src/screens/MeditationsCategoryScreen.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { ScrollView, RefreshControl } from 'react-native';
 
-import appPropTypes from '../propTypes';
 import { getCommonNavigationOptions } from '../navigation/common';
 import BackButton from '../navigation/BackButton';
 import MeditationListCard from '../components/MeditationListCard';
@@ -19,7 +18,6 @@ const MeditationsCategoryScreen = ({
   meditations,
   refreshing,
   refreshCategory,
-  navigation,
 }) => (
   <ScrollView
     refreshControl={
@@ -35,10 +33,6 @@ const MeditationsCategoryScreen = ({
           <MeditationListCard
             key={meditation.id}
             meditation={meditation}
-            onPress={() => navigation.navigate({
-              routeName: 'SingleMeditation',
-              params: { meditation },
-            })}
           />
         ),
       )
@@ -52,7 +46,6 @@ MeditationsCategoryScreen.propTypes = {
   ),
   refreshing: PropTypes.bool.isRequired,
   refreshCategory: PropTypes.func.isRequired,
-  navigation: appPropTypes.navigation.isRequired,
 };
 
 MeditationsCategoryScreen.defaultProps = {

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -20,6 +20,7 @@ import patreonBackground from '../../assets/patreon_bg.png';
 import * as actions from '../state/ducks/patreon/actions';
 import * as selectors from '../state/ducks/patreon/selectors';
 import * as constants from '../state/ducks/patreon/constants';
+import * as ormActions from '../state/ducks/orm/actions';
 import appStyles from '../styles';
 
 const styles = StyleSheet.create({
@@ -217,6 +218,7 @@ const PatreonConnectButton = ({
   isConnected,
   connect: connectPatreon,
   disconnect,
+  fetchData,
 }) => {
   const title = isConnected ? 'Disconnect Patreon' : 'Connect with Patreon';
   const onPress = (
@@ -229,7 +231,11 @@ const PatreonConnectButton = ({
           {
             text: 'Disconnect',
             style: 'destructive',
-            onPress: () => disconnect(),
+            onPress: () => {
+              disconnect();
+              fetchData({ resource: 'podcastEpisode' });
+              fetchData({ resource: 'meditation' });
+            },
           },
         ],
       )
@@ -250,9 +256,15 @@ PatreonConnectButton.propTypes = {
   isConnected: PropTypes.bool.isRequired,
   connect: PropTypes.func.isRequired,
   disconnect: PropTypes.func.isRequired,
+  fetchData: PropTypes.func.isRequired,
 };
 
-const PatreonManageButton = ({ isConnected, pledge, getDetails }) => (
+const PatreonManageButton = ({
+  isConnected,
+  pledge,
+  getDetails,
+  fetchData,
+}) => (
   isConnected &&
     <PatreonButton
       title="Manage Your Pledge"
@@ -265,7 +277,11 @@ const PatreonManageButton = ({ isConnected, pledge, getDetails }) => (
         const pledgeUrl =
           `${constants.BASE_URL}/${pledgeSlug}`;
         WebBrowser.openAuthSessionAsync(pledgeUrl)
-          .then(() => getDetails());
+          .then(() => {
+            getDetails();
+            fetchData({ resource: 'podcastEpisode' });
+            fetchData({ resource: 'meditation' });
+          });
       }}
     />
 );
@@ -317,4 +333,9 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, actions)(PatreonScreen);
+const allActions = {
+  ...actions,
+  ...ormActions,
+};
+
+export default connect(mapStateToProps, allActions)(PatreonScreen);

--- a/src/screens/PlayerScreen/AudioTimeline.js
+++ b/src/screens/PlayerScreen/AudioTimeline.js
@@ -117,8 +117,8 @@ function mapStateToProps(state) {
   return {
     isLoading: selectors.isLoading(state),
     isBuffering: selectors.isBuffering(state),
-    elapsed: selectors.elapsed(state),
-    duration: selectors.duration(state),
+    elapsed: moment.duration(selectors.elapsed(state)),
+    duration: moment.duration(selectors.duration(state)),
   };
 }
 

--- a/src/screens/PodcastScreen.js
+++ b/src/screens/PodcastScreen.js
@@ -71,7 +71,11 @@ function mapDispatchToProps(dispatch, { navigation }) {
     refreshCategory: () => {
       dispatch(
         fetchData({
-          id: podcast.id,
+          resource: 'podcastEpisodes',
+          collection: {
+            field: 'podcast',
+            id: podcast.id,
+          },
         }),
       );
     },

--- a/src/screens/PodcastScreen.js
+++ b/src/screens/PodcastScreen.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { ScrollView, RefreshControl } from 'react-native';
 
-import appPropTypes from '../propTypes';
 import { getCommonNavigationOptions } from '../navigation/common';
 import BackButton from '../navigation/BackButton';
 import PodcastEpisodeListCard from '../components/PodcastEpisodeListCard';
@@ -19,7 +18,6 @@ const PodcastScreen = ({
   episodes,
   refreshing,
   refreshCategory,
-  navigation,
 }) => (
   <ScrollView
     refreshControl={
@@ -35,10 +33,6 @@ const PodcastScreen = ({
           <PodcastEpisodeListCard
             key={episode.id}
             episode={episode}
-            onPress={() => navigation.navigate({
-              routeName: 'SinglePodcastEpisode',
-              params: { episode },
-            })}
           />
         ),
       )
@@ -52,7 +46,6 @@ PodcastScreen.propTypes = {
   ),
   refreshing: PropTypes.bool.isRequired,
   refreshCategory: PropTypes.func.isRequired,
-  navigation: appPropTypes.navigation.isRequired,
 };
 
 PodcastScreen.defaultProps = {

--- a/src/state/ducks/orm/epic.js
+++ b/src/state/ducks/orm/epic.js
@@ -73,7 +73,7 @@ const fetchDataEpic = (action$, store) => {
   );
 
   return action$.ofType(FETCH_DATA)
-    .switchMap(action => (
+    .mergeMap(action => (
       sendAPIRequest(client(store.getState()), action.payload)
         .map(json => receiveData({
           ..._.pick(action.payload, ['resource', 'id']),

--- a/src/state/ducks/orm/reducer.js
+++ b/src/state/ducks/orm/reducer.js
@@ -41,6 +41,16 @@ export default combineReducers({
       }
 
       const data = action.payload.json;
+      if (_.isArray(data.items)) {
+        // Replace any existing instances of this model
+        // with what we're receiving from the server
+        // TODO: filter this by (podcast, meditationCategory)
+        // to enable finer-grain pull-to-refresh
+        const modelName = getModelName(action.payload.resource);
+        const Model = session[modelName];
+        Model.all().delete();
+      }
+
       (_.isArray(data.items) ? data.items : [data]).forEach((item) => {
         const modelName = getModelName(getContentType(item));
         const Model = session[modelName];

--- a/src/state/ducks/orm/reducer.js
+++ b/src/state/ducks/orm/reducer.js
@@ -44,11 +44,17 @@ export default combineReducers({
       if (_.isArray(data.items)) {
         // Replace any existing instances of this model
         // with what we're receiving from the server
-        // TODO: filter this by (podcast, meditationCategory)
-        // to enable finer-grain pull-to-refresh
         const modelName = getModelName(action.payload.resource);
         const Model = session[modelName];
-        Model.all().delete();
+        let querySet = Model.all();
+        const { collection } = action.payload;
+        if (collection) {
+          // Filtered refresh fron a podcast/category screen
+          querySet = querySet.filter(
+            obj => obj[collection.field].id === collection.id,
+          );
+        }
+        querySet.delete();
       }
 
       (_.isArray(data.items) ? data.items : [data]).forEach((item) => {

--- a/src/state/ducks/orm/test.js
+++ b/src/state/ducks/orm/test.js
@@ -468,8 +468,10 @@ describe('api epic', () => {
   // These tests are very simple; one action leads to a single other.
   // Other tests that result in multiple actions from the epic
   // will have to be a little more complicated.
+  let store;
 
   describe('when API call succeeds', () => {
+    ({ store } = configureStore({ noEpic: true }));
     const payload = {
       items: {
         fields: {
@@ -490,7 +492,7 @@ describe('api epic', () => {
       const args = { resource: 'foo' };
 
       const action$ = ActionsObservable.of(actions.fetchData(args));
-      const responseAction = await epic(action$).toPromise();
+      const responseAction = await epic(action$, store).toPromise();
 
       const expectedAction = actions.receiveData({
         ...args,
@@ -512,7 +514,7 @@ describe('api epic', () => {
       const args = { resource: 'foo' };
 
       const action$ = ActionsObservable.of(actions.fetchData(args));
-      const errorAction = await epic(action$).toPromise();
+      const errorAction = await epic(action$, store).toPromise();
 
       expect(errorAction.type).toEqual(types.RECEIVE_API_ERROR);
       expect(errorAction.payload.error).toBeInstanceOf(Error);

--- a/src/state/ducks/patreon/epic.js
+++ b/src/state/ducks/patreon/epic.js
@@ -17,6 +17,7 @@ import {
 
 import _ from 'lodash';
 import axios from 'axios';
+import axiosRetry from 'axios-retry';
 import { AuthSession } from 'expo';
 import qs from 'qs';
 
@@ -26,6 +27,11 @@ import { CONNECT, GET_DETAILS } from './types';
 import * as actions from './actions';
 import * as selectors from './selectors';
 import showError from '../../../showError';
+
+axiosRetry(axios, {
+  retries: 5,
+  retryDelay: axiosRetry.exponentialDelay,
+});
 
 function generateCsrfToken() {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -24,7 +24,7 @@ const migrations = {
 const persistConfig = {
   key: 'root',
   storage,
-  blacklist: ['auth'],
+  blacklist: ['auth', 'playback'],
   version: 0,
   migrate: createMigrate(migrations),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,6 +1474,13 @@ axios-mock-adapter@^1.10.0:
   dependencies:
     deep-equal "^1.0.1"
 
+axios-retry@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.1.2.tgz#4f4dcbefb0b434e22b72bd5e28a027d77b8a3458"
+  integrity sha512-+X0mtJ3S0mmia1kTVi1eA3DAC+oWnT2A29g3CpkzcBPMT6vJm+hn/WiV9wPt/KXLHVmg5zev9mWqkPx7bHMovg==
+  dependencies:
+    is-retry-allowed "^1.1.0"
+
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
@@ -6433,6 +6440,11 @@ is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
+
+is-retry-allowed@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+  integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
 is-root@1.0.0:
   version "1.0.0"
@@ -11688,7 +11700,7 @@ url-loader@^0.6.2:
     mime "^1.4.1"
     schema-utils "^0.3.0"
 
-url-parse@^1.1.8, url-parse@^1.1.9, url-parse@^1.4.3:
+url-parse@^1.1.8, url-parse@^1.1.9, url-parse@^1.4.3, url-parse@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
   integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==


### PR DESCRIPTION
## Description
This moves all Contentful configuration to the backend, relying on the content filtering implemented in https://github.com/theliturgists/backend/compare/fc9035314396cb71f56724b1d63f08cea5f3a2dd...669a59fff8010beca8147ae253cd6864970baf8c . The app provides the Patreon bearer token, and the backend does the filtering. 

For `podcastEpisode` and `meditation`, the backend omits media URLs for filtered content and sets a `patronsOnly` flag. There is also an `isFreePreview` field that can be used to show some content to non-patrons.

## Motivation and Context
Closes #100.

## How Has This Been Tested?
- Poked around the app with different patron states:
  - Patreon disconnected
  - Non-patron
  - $1 patron
  - $5 patron
- Verified that the correct content was displayed in all cases, immediately after changing the Patreon setting

## Screenshots

<ul>
<li>Patreon disconnected / non-patron</li>
<ul>
<li><details>
<summary>$1-minimum podcast</summary>
<img src="https://user-images.githubusercontent.com/91550/53093090-71ec2500-34e4-11e9-980a-07a6b0f2a409.png"/>
</details></li>

<li><details>
<summary>Meditations</summary>
<img src="https://user-images.githubusercontent.com/91550/53093168-acee5880-34e4-11e9-9516-0b8714a4f01e.png" />
</details></li>
</ul>

<li><details>
<summary>Tap on inaccessible content opens Patreon screen</summary>
<img src="https://user-images.githubusercontent.com/91550/53093322-179f9400-34e5-11e9-8662-8635ae3aead4.gif" />
</details></li>
</ul>