### PR TITLE
Support audio hosted in contentful

### DIFF
--- a/src/components/PlayerStrip.js
+++ b/src/components/PlayerStrip.js
@@ -67,7 +67,7 @@ const styles = StyleSheet.create({
 
 function getSeriesTitle(item) {
   const group = ['category', 'podcast', 'liturgy'].find(g => _.has(item, g));
-  return _.isUndefined(group) ? null : item[group].title;
+  return _.get(item, [group, 'title']);
 }
 
 const PlayerStrip = ({ item, navigation: { navigate } }) => (

--- a/src/screens/PlayerScreen/index.js
+++ b/src/screens/PlayerScreen/index.js
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
 
 function getSeriesTitle(item) {
   const group = ['category', 'podcast', 'liturgy'].find(g => _.has(item, g));
-  return _.isUndefined(group) ? null : item[group].title;
+  return _.get(item, [group, 'title']);
 }
 
 class PlayerScreen extends React.Component {

--- a/src/state/ducks/orm/selectors.js
+++ b/src/state/ducks/orm/selectors.js
@@ -113,10 +113,10 @@ const modelToObject = {
 };
 
 const modelOrderArgs = {
-  Meditation: ['publishedAt', 'title'],
+  Meditation: [['publishedAt', 'title'], ['desc', 'asc']],
   MeditationCategory: ['title'],
   Podcast: ['title'],
-  PodcastEpisode: ['publishedAt', 'title'],
+  PodcastEpisode: [['publishedAt', 'title'], ['desc', 'asc']],
   PodcastSeason: ['title'],
   Contributor: ['name'],
   Tag: ['name'],

--- a/src/state/ducks/orm/utils.js
+++ b/src/state/ducks/orm/utils.js
@@ -88,3 +88,11 @@ export function getImageSource(item, large = false) {
   const collectionImageUrl = collection[imageKey] || collection[imageUrlKey];
   return collectionImageUrl ? imageSource(collectionImageUrl) : placeholderImage;
 }
+
+export function getMediaSource(item) {
+  const uri = item.media || item.mediaUrl;
+  if (uri) {
+    return { uri };
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Description
Same as we were already doing with `image` and `largeImage`.

## Motivation and Context
Publishing new content should be a one-step process. Adding external media and then linking to it is more complicated.

Closes #114.

## How Has This Been Tested?
Added a test meditation with a contentful-hosted audio file. It loaded in the player and played.