### PR TITLE
Render html item descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "axios-retry": "^3.1.2",
     "contentful": "^7.1.0",
     "expo": "^31.0.4",
+    "html-entities": "^1.2.1",
+    "is-html": "^1.1.0",
     "jsonapi-datastore": "^0.4.0-beta",
     "lodash": "^4.17.4",
     "moment": "^2.20.1",
@@ -53,6 +55,7 @@
     "redux-orm": "^0.11.0",
     "redux-persist": "^5.10.0",
     "redux-persist-expo-securestore": "^0.1.1",
+    "remarkable": "^1.7.1",
     "rxjs": "^5.5.6",
     "url-parse": "^1.4.4"
   },

--- a/src/components/ItemDescription.js
+++ b/src/components/ItemDescription.js
@@ -1,15 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
+import { WebBrowser } from 'expo';
 
-import Markdown from 'react-native-markdown-renderer';
+import Remarkable from 'remarkable';
+import HTML from 'react-native-render-html';
+import { AllHtmlEntities } from 'html-entities';
+import isHtml from 'is-html';
 
 import SectionHeader from './SectionHeader';
+
+const md = new Remarkable('commonmark');
+const entities = new AllHtmlEntities();
+
+export function renderDescription(description) {
+  if (isHtml(description)) {
+    return entities.decode(description);
+  }
+  return md.render(description);
+}
 
 const ItemDescription = ({ description, label }) => (
   <View>
     <SectionHeader>{label}</SectionHeader>
-    <Markdown>{description}</Markdown>
+    <HTML
+      html={renderDescription(description)}
+      onLinkPress={(evt, href) => WebBrowser.openBrowserAsync(href)}
+    />
   </View>
 );
 

--- a/src/components/PlayableListCard.js
+++ b/src/components/PlayableListCard.js
@@ -17,12 +17,14 @@ import pluralize from 'pluralize';
 import ListCard from './ListCard';
 import SquareImage from './SquareImage';
 import TextPill from './TextPill';
+import { renderDescription } from './ItemDescription';
 import { formatMinutesString } from './utils';
 import * as navActions from '../navigation/actions';
 
 import appPropTypes from '../propTypes';
 import * as actions from '../state/ducks/playback/actions';
 import { getImageSource } from '../state/ducks/orm/utils';
+
 
 const styles = StyleSheet.create({
   card: {
@@ -137,6 +139,10 @@ const PatronsOnlyIcon = () => (
   <FontAwesome name="lock" style={styles.patronsOnlyIcon} />
 );
 
+function stripTags(html) {
+  return html.replace(/<[^>]+>/g, '');
+}
+
 const PlayableListCard = ({
   style,
   formatDuration,
@@ -194,7 +200,7 @@ const PlayableListCard = ({
           ]}
           numberOfLines={2}
         >
-          {item.description}
+          {stripTags(renderDescription(item.description))}
         </Text>
       </View>
       {isSearchResult ? null : (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,6 +1223,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@~0.1.15:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c"
+  integrity sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=
+  dependencies:
+    underscore "~1.7.0"
+    underscore.string "~2.4.0"
+
 argsarray@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"
@@ -1432,6 +1440,11 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+autolinker@~0.15.0:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-0.15.3.tgz#342417d8f2f3461b14cf09088d5edf8791dc9832"
+  integrity sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=
 
 autoprefixer@^6.3.1:
   version "6.7.7"
@@ -5822,7 +5835,7 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-html-entities@^1.2.0:
+html-entities@^1.2.0, html-entities@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
@@ -5855,6 +5868,11 @@ html-tag-names@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.3.tgz#f81f75e59d626cb8a958a19e58f90c1d69707b82"
   integrity sha512-kY/ck6Q0lGLxGocn86BM8Q4vCTUCY78VN43h0uMGeZ8p9LU3XdSNQR4Rs3JEjrKZSS5iXI1YgzY0g8U1AFDQzA==
+
+html-tags@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-1.2.0.tgz#c78de65b5663aa597989dd2b7ab49200d7e4db98"
+  integrity sha1-x43mW1Zjqll5id0rerSSANfk25g=
 
 html-webpack-plugin@^2.30.1:
   version "2.30.1"
@@ -6363,6 +6381,13 @@ is-glob@^4.0.0:
   integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
   dependencies:
     is-extglob "^2.1.1"
+
+is-html@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-html/-/is-html-1.1.0.tgz#e04f1c18d39485111396f9a0273eab51af218464"
+  integrity sha1-4E8cGNOUhRETlvmgJz6rUa8hhGQ=
+  dependencies:
+    html-tags "^1.0.0"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -10273,6 +10298,14 @@ relateurl@0.2.x:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remarkable@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-1.7.1.tgz#aaca4972100b66a642a63a1021ca4bac1be3bff6"
+  integrity sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=
+  dependencies:
+    argparse "~0.1.15"
+    autolinker "~0.15.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -11581,6 +11614,16 @@ ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
   integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
+
+underscore.string@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
+  integrity sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=
+
+underscore@~1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Description
The episode and meditation descriptions imported from Patreon have HTML content, which needs to be rendered when displaying in the app. Also renders Markdown descriptions to html, then renders the html for display.

For descriptions in list cards, we take the html and strip all the tags, leaving just unstyled text.

## How Has This Been Tested?
Found several meditations with and without html content; checked that they looked ok in the app.