### PR TITLE
Fix pull to refresh issues on category/podcast screens

### DIFF
--- a/src/components/MeditationSeriesList.js
+++ b/src/components/MeditationSeriesList.js
@@ -19,12 +19,11 @@ const MeditationSeriesList = ({ meditationCategories, onPressMeditationCategory 
     <ScrollView>
       <View style={styles.list}>
         {meditationCategories.map(meditationCategory => (
-          meditationCategory.meditations.length > 0 &&
-            <MeditationSeriesTile
-              key={meditationCategory.title}
-              meditationCategory={meditationCategory}
-              onPress={() => onPressMeditationCategory(meditationCategory)}
-            />
+          <MeditationSeriesTile
+            key={meditationCategory.title}
+            meditationCategory={meditationCategory}
+            onPress={() => onPressMeditationCategory(meditationCategory)}
+          />
         ))}
       </View>
     </ScrollView>

--- a/src/components/MeditationSeriesTile.js
+++ b/src/components/MeditationSeriesTile.js
@@ -1,12 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import { connect } from 'react-redux';
 
 import SeriesTile from './SeriesTile';
 import MeditationCategory from '../state/models/MeditationCategory';
+import Meditation from '../state/models/Meditation';
 import { getImageSource } from '../state/ducks/orm/utils';
+import { meditationsSelector } from '../state/ducks/orm/selectors';
 
-const formatMeditationCount = (meditationCount) => {
+const formatMeditationCount = (category, meditations) => {
+  const meditationCount = (category.title === 'All Meditations'
+    ? meditations.length
+    : _.get(category, 'meditations.length', 0)
+  );
   let meditationString = 'Meditations';
   if (meditationCount === 1) {
     meditationString = 'Meditation';
@@ -14,13 +21,13 @@ const formatMeditationCount = (meditationCount) => {
   return `${meditationCount} ${meditationString}`;
 };
 
-const MeditationSeriesTile = ({ meditationCategory, onPress }) => (
+const MeditationSeriesTile = ({ meditationCategory, onPress, meditations }) => (
   <SeriesTile
     imageSource={getImageSource(meditationCategory)}
     title={meditationCategory.title}
     onPress={() => onPress(meditationCategory)}
     description={
-      formatMeditationCount(_.get(meditationCategory, 'meditations.length', 0))
+      formatMeditationCount(meditationCategory, meditations)
     }
   />
 );
@@ -30,10 +37,19 @@ MeditationSeriesTile.propTypes = {
     MeditationCategory.propTypes,
   ).isRequired,
   onPress: PropTypes.func,
+  meditations: PropTypes.arrayOf(
+    PropTypes.shape(Meditation.propTypes),
+  ).isRequired,
 };
 
 MeditationSeriesTile.defaultProps = {
   onPress: () => {},
 };
 
-export default MeditationSeriesTile;
+function mapStateToProps(state) {
+  return {
+    meditations: meditationsSelector(state),
+  };
+}
+
+export default connect(mapStateToProps)(MeditationSeriesTile);

--- a/src/screens/MeditationsCategoryScreen.js
+++ b/src/screens/MeditationsCategoryScreen.js
@@ -17,13 +17,13 @@ import { fetchData } from '../state/ducks/orm';
 const MeditationsCategoryScreen = ({
   meditations,
   refreshing,
-  refreshCategory,
+  refreshMeditations,
 }) => (
   <ScrollView
     refreshControl={
       <RefreshControl
         refreshing={refreshing}
-        onRefresh={() => refreshCategory()}
+        onRefresh={() => refreshMeditations()}
       />
     }
   >
@@ -45,7 +45,7 @@ MeditationsCategoryScreen.propTypes = {
     PropTypes.shape(Meditation.propTypes).isRequired,
   ),
   refreshing: PropTypes.bool.isRequired,
-  refreshCategory: PropTypes.func.isRequired,
+  refreshMeditations: PropTypes.func.isRequired,
 };
 
 MeditationsCategoryScreen.defaultProps = {
@@ -69,22 +69,12 @@ function mapStateToProps(state, { navigation }) {
   };
 }
 
-function mapDispatchToProps(dispatch, { navigation }) {
-  const { state: { params: { category } } } = navigation;
-
+function mapDispatchToProps(dispatch) {
   return {
-    refreshCategory: () => {
-      let collection;
-      if (category.title !== 'All Meditations') {
-        collection = {
-          field: 'category',
-          id: category.id,
-        };
-      }
+    refreshMeditations: () => {
       dispatch(
         fetchData({
           resource: 'meditations',
-          collection,
         }),
       );
     },

--- a/src/screens/MeditationsCategoryScreen.js
+++ b/src/screens/MeditationsCategoryScreen.js
@@ -8,7 +8,11 @@ import BackButton from '../navigation/BackButton';
 import MeditationListCard from '../components/MeditationListCard';
 import * as patreonSelectors from '../state/ducks/patreon/selectors';
 import Meditation from '../state/models/Meditation';
-import { meditationCategorySelector, apiLoadingSelector } from '../state/ducks/orm/selectors';
+import {
+  meditationCategorySelector,
+  meditationsSelector,
+  apiLoadingSelector,
+} from '../state/ducks/orm/selectors';
 import { fetchData } from '../state/ducks/orm';
 
 /**
@@ -56,7 +60,7 @@ function mapStateToProps(state, { navigation }) {
   const { state: { params: { category } } } = navigation;
   const meditations = (
     category.title === 'All Meditations'
-      ? category.meditations
+      ? meditationsSelector(state)
       : meditationCategorySelector(state, category.id).meditations
   );
   return {

--- a/src/screens/MeditationsScreen.js
+++ b/src/screens/MeditationsScreen.js
@@ -8,7 +8,6 @@ import { getCommonNavigationOptions } from '../navigation/common';
 import MeditationSeriesList from '../components/MeditationSeriesList';
 import * as patreonSelectors from '../state/ducks/patreon/selectors';
 import { fetchData } from '../state/ducks/orm';
-import Meditation from '../state/models/Meditation';
 import MeditationCategory from '../state/models/MeditationCategory';
 import {
   meditationsSelector,
@@ -26,11 +25,10 @@ class MeditationsScreen extends Component {
   }
 
   render() {
-    const { meditations, categories, navigation } = this.props;
+    const { categories, navigation } = this.props;
     const meditationCategories = [
       {
         title: 'All Meditations',
-        meditations,
         imageUrl: 'https://static1.squarespace.com/static/52fd5845e4b074ebcf586e7b/t/5a6b935be4966b484105c9d3/1516999519606/Centering+Prayer+Cover+Art.jpeg?format=500w',
       },
       ...categories,
@@ -58,9 +56,6 @@ class MeditationsScreen extends Component {
 }
 
 MeditationsScreen.propTypes = {
-  meditations: PropTypes.arrayOf(
-    PropTypes.shape(Meditation.propTypes),
-  ),
   categories: PropTypes.arrayOf(
     PropTypes.shape(MeditationCategory.propTypes),
   ),
@@ -70,7 +65,6 @@ MeditationsScreen.propTypes = {
 };
 
 MeditationsScreen.defaultProps = {
-  meditations: [],
   categories: [],
 };
 

--- a/src/screens/PodcastScreen.js
+++ b/src/screens/PodcastScreen.js
@@ -17,13 +17,13 @@ import { fetchData } from '../state/ducks/orm';
 const PodcastScreen = ({
   episodes,
   refreshing,
-  refreshCategory,
+  refreshPodcastEpisodes,
 }) => (
   <ScrollView
     refreshControl={
       <RefreshControl
         refreshing={refreshing}
-        onRefresh={() => refreshCategory()}
+        onRefresh={() => refreshPodcastEpisodes()}
       />
     }
   >
@@ -45,7 +45,7 @@ PodcastScreen.propTypes = {
     PropTypes.shape(PodcastEpisode.propTypes).isRequired,
   ),
   refreshing: PropTypes.bool.isRequired,
-  refreshCategory: PropTypes.func.isRequired,
+  refreshPodcastEpisodes: PropTypes.func.isRequired,
 };
 
 PodcastScreen.defaultProps = {
@@ -59,23 +59,17 @@ function mapStateToProps(state, { navigation }) {
     episodes,
     isPatron: patreonSelectors.isPatron(state),
     refreshing: (
-      apiLoadingSelector(state, 'podcast')
+      apiLoadingSelector(state, 'podcastEpisodes')
     ),
   };
 }
 
-function mapDispatchToProps(dispatch, { navigation }) {
-  const { state: { params: { podcast } } } = navigation;
-
+function mapDispatchToProps(dispatch) {
   return {
-    refreshCategory: () => {
+    refreshPodcastEpisodes: () => {
       dispatch(
         fetchData({
           resource: 'podcastEpisodes',
-          collection: {
-            field: 'podcast',
-            id: podcast.id,
-          },
         }),
       );
     },

--- a/src/state/ducks/orm/reducer.js
+++ b/src/state/ducks/orm/reducer.js
@@ -52,9 +52,11 @@ export default combineReducers({
         let querySet = Model.all();
         const { collection } = action.payload;
         if (collection) {
-          // Filtered refresh fron a podcast/category screen
+          // Filtered refresh (not actually used at the moment; left over
+          // from a previous iteration)
           querySet = querySet.filter(
-            obj => _.get(obj, [collection.field, 'id']) === collection.id,
+            // in reducers, relations are _just_ the id of the related object
+            obj => obj[collection.field] === collection.id,
           );
         }
         querySet = querySet.filter(


### PR DESCRIPTION
## Description
Fixes a bug where pull-to-refresh didn't function as expected from category/podcast screens (but did work for the all-categories/all-podcasts screens). Now, refreshing correctly:
- adds newly published items
- shows updated items
- removes unpublished items

TODO:
- [ ] fix the issue where the loading indicator disappears too quickly