### PR TITLE
Use backend shim for Patreon oauth initiation

### DIFF
--- a/ci/deploy-to-expo.sh
+++ b/ci/deploy-to-expo.sh
@@ -3,7 +3,7 @@
 yarn global add exp
 
 fail=
-for name in EXPO_USERNAME EXPO_PASSWORD CIRCLE_BRANCH PATREON_CLIENT_ID ; do
+for name in EXPO_USERNAME EXPO_PASSWORD CIRCLE_BRANCH ; do
   eval value=\$$name
   if [[ -z ${value} ]]; then
     echo >&2 "Missing required env variable: ${name}"
@@ -16,9 +16,7 @@ if [[ -n $fail ]]; then
 fi
 
 api_url="https://staging.api.theliturgists.com"
-json -I -f config.json \
-  -e "this.apiBaseUrl='${api_url}'" \
-  -e "this.patreonClientId='${PATREON_CLIENT_ID}'" \
+json -I -f config.json -e "this.apiBaseUrl='${api_url}'"
 
 exp login -u "${EXPO_USERNAME}" -p "${EXPO_PASSWORD}"
 

--- a/src/state/ducks/patreon/epic.js
+++ b/src/state/ducks/patreon/epic.js
@@ -51,9 +51,8 @@ function getPatreonToken() {
   const csrfToken = generateCsrfToken();
   const redirectUrl = AuthSession.getRedirectUrl();
   const authUrl = (
-    'https://www.patreon.com/oauth2/authorize' +
+    `${config.apiBaseUrl}/patreon/authorize` +
     '?response_type=code' +
-    `&client_id=${config.patreonClientId}` +
     `&redirect_uri=${redirectUrl}` +
     `&state=${csrfToken}`
   );


### PR DESCRIPTION
This lets us remove the Patreon client_id from the app, so that we now
only have to update it in one place (AWS SSM).

Depends on https://github.com/theliturgists/backend/commit/db0affad73b67d144596fb98b488b2c0762dcb79.