### PR TITLE
Fix uneven margins around images in series tiles

### DIFF
--- a/src/components/SeriesTile.js
+++ b/src/components/SeriesTile.js
@@ -7,7 +7,11 @@ import colors from '../styles/colors';
 import SquareImage from './SquareImage';
 
 import appPropTypes from '../propTypes';
+import { screenRelativeWidth } from './utils';
 
+
+// using the width of the container, adjusted for padding, margin, and border radius
+const imageWidth = screenRelativeWidth(0.46) - 9 - 6 - 4;
 
 const styles = StyleSheet.create({
   // Tile wrapper base
@@ -20,7 +24,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 6,
     marginVertical: 6,
     padding: 9,
-    width: '46%',
+    width: screenRelativeWidth(0.46),
     borderRadius: 4,
     justifyContent: 'center',
     alignItems: 'center',
@@ -40,7 +44,7 @@ const styles = StyleSheet.create({
   imageContainer: {
     flex: 1,
     width: null,
-    height: 150,
+    height: imageWidth,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -79,7 +83,7 @@ const SeriesTile = ({
       <View style={styles.imageContainer}>
         <SquareImage
           source={imageSource}
-          width={150}
+          width={imageWidth}
         />
       </View>
       <View style={styles.textContainer}>


### PR DESCRIPTION
## Description
Bit of a hack, but it ensures the image and its container are sized the
same way as the outer container.

## Motivation and Context
Closes #105.

## Screenshots (if appropriate):
Taken with the element inspector set on the tile. Note the sliver of blue to the left and right of the image in the "Before" shot, and its absence in "After".

| Before | After |
| ---- | ---- |
| <img width="203" alt="screen shot 2019-03-06 at 10 22 46 pm" src="https://user-images.githubusercontent.com/91550/53930268-bb00b500-405e-11e9-9b9f-461e880d3d26.png"> | <img width="203" alt="screen shot 2019-03-06 at 10 23 09 pm" src="https://user-images.githubusercontent.com/91550/53930275-be943c00-405e-11e9-95e9-afc33d5b72be.png"> |