### PR TITLE
Tweaks to the player strip

### DIFF
--- a/src/components/PlayerStrip.js
+++ b/src/components/PlayerStrip.js
@@ -78,6 +78,7 @@ const styles = StyleSheet.create({
   },
   pauseButtonIconStyle: {
     marginTop: 2,
+    marginLeft: 1,
     fontSize: 16,
     color: '#7B7B7B',
   },

--- a/src/components/PlayerStrip.js
+++ b/src/components/PlayerStrip.js
@@ -14,8 +14,7 @@ import { getImageSource } from '../state/ducks/orm/utils';
 const styles = StyleSheet.create({
   container: {
     padding: 7,
-    paddingLeft: 18,
-    paddingRight: 7,
+    paddingHorizontal: 18,
     height: 50,
     flexDirection: 'row',
     backgroundColor: '#fff',
@@ -48,7 +47,7 @@ const styles = StyleSheet.create({
     flex: 1,
     marginVertical: 10,
     textAlign: 'center',
-    marginLeft: 10,
+    marginHorizontal: 10,
   },
   title: {
     fontSize: 14,
@@ -83,13 +82,13 @@ const styles = StyleSheet.create({
     color: '#7B7B7B',
   },
   playbackButtonStyle: {
-    width: 25,
-    height: 25,
-    borderRadius: 25,
+    width: 30,
+    height: 30,
+    borderRadius: 30,
     borderColor: '#7B7B7B',
     borderWidth: 1,
     marginLeft: 0,
-    marginRight: 10,
+    marginRight: 0,
   },
 });
 
@@ -115,15 +114,16 @@ const PlayerStrip = ({ item, navigation: { navigate } }) => (
             <Text style={styles.title} numberOfLines={1}>{item.title}</Text>
             <Text style={styles.seriesTitle} numberOfLines={1}>{getSeriesTitle(item)}</Text>
           </View>
+          {/* XXX: this can be simplified to just use the PlaybackButton instead. */}
+          <Controls
+            style={styles.controls}
+            jumpButtonStyle={styles.jumpButtonStyle}
+            jumpButtonIconStyle={styles.jumpButtonIconStyle}
+            playbackButtonStyle={styles.playbackButtonStyle}
+            playButtonIconStyle={styles.playButtonIconStyle}
+            pauseButtonIconStyle={styles.pauseButtonIconStyle}
+          />
         </View>
-        <Controls
-          style={styles.controls}
-          jumpButtonStyle={styles.jumpButtonStyle}
-          jumpButtonIconStyle={styles.jumpButtonIconStyle}
-          playbackButtonStyle={styles.playbackButtonStyle}
-          playButtonIconStyle={styles.playButtonIconStyle}
-          pauseButtonIconStyle={styles.pauseButtonIconStyle}
-        />
       </View>
     </TouchableWithoutFeedback>
   ) : null


### PR DESCRIPTION
## Description
- Make the image and the playback button the same size
- Move playback button inside container
- Move padding to outside the container

## Motivation and Context
Text was not centered after #148 landed.

## Screenshots

| | |
| ---- | ---- |
| Before | <img width="437" alt="screen shot 2019-03-07 at 10 51 21 am" src="https://user-images.githubusercontent.com/91550/53969552-00f16380-40c7-11e9-8daf-cd8c2815efc3.png"> |
| After | <img width="437" alt="screen shot 2019-03-07 at 11 01 23 am" src="https://user-images.githubusercontent.com/91550/53970293-5c702100-40c8-11e9-9d15-8c41514b9f0e.png"> |
