### PR TITLE
Refresh Patreon token on 401 error

### DIFF
--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -273,10 +273,10 @@ const PatreonRefreshButton = ({
     />
 );
 
-PatreonConnectButton.propTypes = {
+PatreonRefreshButton.propTypes = {
   isConnected: PropTypes.bool.isRequired,
-  connect: PropTypes.func.isRequired,
-  disconnect: PropTypes.func.isRequired,
+  getDetails: PropTypes.func.isRequired,
+  fetchData: PropTypes.func.isRequired,
 };
 
 const PatreonScreen = props => (

--- a/src/state/ducks/patreon/actions.js
+++ b/src/state/ducks/patreon/actions.js
@@ -26,6 +26,17 @@ export const getDetails = createAction(types.GET_DETAILS);
 export const storeToken = createAction(types.STORE_TOKEN);
 
 /**
+ * Refresh the Patreon access token (after it has expired).
+ *
+ * @param payload {object}
+ *   originalError {Error} the error that prompted this refresh,
+ *     which will be stored and displayed if the refresh fails.
+ *   retryAction {Action} the action that prompted this refresh,
+ *     which will be re-dispatched after the token is refreshed.
+ */
+export const refreshAccessToken = createAction(types.REFRESH_ACCESS_TOKEN);
+
+/**
  * Save the Patreon pledge details.
  */
 export const storeDetails = createAction(types.STORE_DETAILS);

--- a/src/state/ducks/patreon/selectors.js
+++ b/src/state/ducks/patreon/selectors.js
@@ -2,11 +2,15 @@ import _ from 'lodash';
 import { JsonApiDataStore } from 'jsonapi-datastore';
 
 export function token(state) {
-  return state.auth.patreonToken;
+  return _.get(state.auth.patreonToken, 'access_token');
+}
+
+export function refreshToken(state) {
+  return _.get(state.auth.patreonToken, 'refresh_token');
 }
 
 export function isConnected(state) {
-  return token(state) !== null;
+  return !!token(state);
 }
 
 export function getPledge(state) {

--- a/src/state/ducks/patreon/test.js
+++ b/src/state/ducks/patreon/test.js
@@ -1,12 +1,16 @@
-// import { ActionsObservable } from 'redux-observable';
-// import axios from 'axios';
-// import MockAdapter from 'axios-mock-adapter';
+import { ActionsObservable } from 'redux-observable';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 
 import configureStore from '../../store';
 // import * as types from './types';
 import * as actions from './actions';
 import * as selectors from './selectors';
-// import epic from './epic';
+import epic from './epic';
+
+import config from '../../../../config.json';
+
+const mock = new MockAdapter(axios);
 
 /*
  * Reducers are tested by stubbing out the epic with one that does nothing,
@@ -23,6 +27,7 @@ import * as selectors from './selectors';
 
 describe('patreon reducer', () => {
   let store;
+  const token = { access_token: 'foo', refresh_token: 'bar' };
 
   beforeEach(() => {
     ({ store } = configureStore({ noEpic: true }));
@@ -33,12 +38,12 @@ describe('patreon reducer', () => {
   });
 
   test('storeToken() enables patreon', () => {
-    store.dispatch(actions.storeToken());
+    store.dispatch(actions.storeToken(token));
     expect(selectors.isConnected(store.getState())).toBe(true);
   });
 
   test('disconnect() disables patreon', () => {
-    store.dispatch(actions.storeToken());
+    store.dispatch(actions.storeToken(token));
     expect(selectors.isConnected(store.getState())).toBe(true);
 
     store.dispatch(actions.disconnect());
@@ -57,4 +62,60 @@ describe('patreon reducer', () => {
 
 describe('patreon epic', () => {
   // TODO: mock patreon auth and test epic
+
+  describe('refreshAccessToken()', () => {
+    const retryAction = { type: 'FOO' };
+    const errorAction = { type: 'BAR' };
+    const action = actions.refreshAccessToken({
+      retryAction,
+      errorAction,
+    });
+    let action$;
+    let store;
+
+    let patreonMock;
+
+    beforeEach(() => {
+      ({ store } = configureStore({ noEpic: true }));
+      action$ = ActionsObservable.of(action);
+      patreonMock = mock.onPost(`${config.apiBaseUrl}/patreon/validate`);
+    });
+
+    afterEach(() => {
+      mock.reset();
+    });
+
+    test('leads to retry action if refresh succeeds', async () => {
+      const patreonAuth = {
+        access_token: 'foo',
+        refresh_token: 'bar',
+      };
+      const newPatreonAuth = {
+        access_token: 'baz',
+        refresh_token: 'quux',
+      };
+      store.dispatch(actions.storeToken(patreonAuth));
+      patreonMock.reply(200, newPatreonAuth);
+
+      const resultAction = await epic(action$, store).toPromise();
+      expect(resultAction).toEqual(retryAction);
+    });
+
+    test('leads to error action if refresh fails', async () => {
+      const patreonAuth = {
+        access_token: 'foo',
+        refresh_token: 'bar',
+      };
+      store.dispatch(actions.storeToken(patreonAuth));
+      patreonMock.reply(401, {});
+
+      const resultAction = await epic(action$, store).toPromise();
+      expect(resultAction).toEqual(errorAction);
+    });
+
+    test("leads to error action if there's no refresh token", async () => {
+      const resultAction = await epic(action$, store).toPromise();
+      expect(resultAction).toEqual(errorAction);
+    });
+  });
 });

--- a/src/state/ducks/patreon/types.js
+++ b/src/state/ducks/patreon/types.js
@@ -3,6 +3,7 @@ import { scopedType } from '../../utils';
 export const CONNECT = scopedType('patreon/CONNECT');
 export const DISCONNECT = scopedType('patreon/DISCONNECT');
 export const GET_DETAILS = scopedType('patreon/GET_DETAILS');
+export const REFRESH_ACCESS_TOKEN = scopedType('patreon/REFRESH_ACCESS_TOKEN');
 
 export const STORE_TOKEN = scopedType('patreon/STORE_TOKEN');
 export const STORE_DETAILS = scopedType('patreon/STORE_DETAILS');


### PR DESCRIPTION
## Description
When an API request fails with 401, it's because the Patreon token expired.
So, in the two places where this happens (Patreon and ORM epics), handle
the error, refresh the token, and retry the instigating action if the refresh succeeds.
If the refresh fails, dispatch the original error action.

Note: this doesn't fix the issue where authenticating the same user on a
second device appears to invalidate the refresh token, and it hasn't yet
been tested with a real expiration (since that takes an indeterminate
amount of time). It does have a unit test for the epic, though.

## Motivation and Context
Closes #139.

## How Has This Been Tested?
New unit tests pass. (This is hard to test with realism, since it takes a month-ish for tokens to actually expire.)