### PR TITLE
Load dynamic assets from Contentful

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -8,8 +8,12 @@ import { useScreens } from 'react-native-screens';
 import MainNavigator from './navigation/MainNavigator';
 import { setTopLevelNavigator } from './navigation/NavigationService';
 import configureStore from './state/store';
+import Reactotron from '../reactotron-config';
 
 import config from '../config.json';
+
+// eslint-disable-next-line
+console.tron = Reactotron;
 
 
 if (config.sentryPublicDSN) {

--- a/src/screens/MeditationsScreen.js
+++ b/src/screens/MeditationsScreen.js
@@ -7,11 +7,13 @@ import appPropTypes from '../propTypes';
 import { getCommonNavigationOptions } from '../navigation/common';
 import MeditationSeriesList from '../components/MeditationSeriesList';
 import * as patreonSelectors from '../state/ducks/patreon/selectors';
-import { fetchData } from '../state/ducks/orm';
+import { fetchData, fetchAsset } from '../state/ducks/orm';
+import { ALL_MEDITATIONS_COVER_ART } from '../state/ducks/orm/actions';
 import MeditationCategory from '../state/models/MeditationCategory';
 import {
   meditationsSelector,
   meditationCategoriesSelector,
+  assetUrlSelector,
   apiLoadingSelector,
 } from '../state/ducks/orm/selectors';
 
@@ -20,16 +22,17 @@ import {
  */
 class MeditationsScreen extends Component {
   componentDidMount() {
-    const { fetchMeditations } = this.props;
+    const { fetchMeditations, fetchAllMeditationsCoverArt } = this.props;
     fetchMeditations();
+    fetchAllMeditationsCoverArt();
   }
 
   render() {
-    const { categories, navigation } = this.props;
+    const { categories, navigation, allMeditationsCoverArtUrl } = this.props;
     const meditationCategories = [
       {
         title: 'All Meditations',
-        imageUrl: 'https://images.ctfassets.net/80rg4ikyq3mh/4fw1cG2nsTZ9Upl3jpWDVH/3c71279543e32f52240f9b55d76d9313/meditation-2240777_1280.jpg',
+        imageUrl: allMeditationsCoverArtUrl,
       },
       ...categories,
     ];
@@ -59,19 +62,23 @@ MeditationsScreen.propTypes = {
   categories: PropTypes.arrayOf(
     PropTypes.shape(MeditationCategory.propTypes),
   ),
+  allMeditationsCoverArtUrl: PropTypes.string,
   fetchMeditations: PropTypes.func.isRequired,
+  fetchAllMeditationsCoverArt: PropTypes.func.isRequired,
   refreshing: PropTypes.bool.isRequired,
   navigation: appPropTypes.navigation.isRequired,
 };
 
 MeditationsScreen.defaultProps = {
   categories: [],
+  allMeditationsCoverArtUrl: null,
 };
 
 function mapStateToProps(state) {
   return {
     meditations: meditationsSelector(state),
     categories: meditationCategoriesSelector(state),
+    allMeditationsCoverArtUrl: assetUrlSelector(state, ALL_MEDITATIONS_COVER_ART),
     isPatron: patreonSelectors.isPatron(state),
     refreshing: apiLoadingSelector(state, 'meditations'),
   };
@@ -83,6 +90,9 @@ function mapDispatchToProps(dispatch) {
       fetchData({
         resource: 'meditations',
       }),
+    ),
+    fetchAllMeditationsCoverArt: () => dispatch(
+      fetchAsset(ALL_MEDITATIONS_COVER_ART),
     ),
   };
 }

--- a/src/state/ducks/orm/actions.js
+++ b/src/state/ducks/orm/actions.js
@@ -2,13 +2,20 @@ import { createAction } from 'redux-actions';
 
 import {
   FETCH_DATA,
+  FETCH_ASSET,
   RECEIVE_DATA,
+  RECEIVE_ASSET,
   RECEIVE_API_ERROR,
 } from './types';
 
+// asset keys
+export const ALL_MEDITATIONS_COVER_ART = 'all_meditations_cover_art';
+
 // dispatched by views
 export const fetchData = createAction(FETCH_DATA);
+export const fetchAsset = createAction(FETCH_ASSET);
 
 // emitted by epics
 export const receiveData = createAction(RECEIVE_DATA);
+export const receiveAsset = createAction(RECEIVE_ASSET);
 export const receiveApiError = createAction(RECEIVE_API_ERROR);

--- a/src/state/ducks/orm/index.js
+++ b/src/state/ducks/orm/index.js
@@ -1,3 +1,3 @@
-export { fetchData } from './actions';
+export { fetchData, fetchAsset } from './actions';
 export { default as epic } from './epic';
 export { default } from './reducer';

--- a/src/state/ducks/orm/reducer.js
+++ b/src/state/ducks/orm/reducer.js
@@ -4,10 +4,11 @@ import { handleActions } from 'redux-actions';
 
 import orm from '../../orm';
 
-import { FETCH_DATA, RECEIVE_DATA, RECEIVE_API_ERROR } from './types';
+import { FETCH_DATA, RECEIVE_DATA, RECEIVE_ASSET, RECEIVE_API_ERROR } from './types';
 import { getModelName, getContentType, getFields, getRelationships, getAssets } from './utils';
 
 const defaultORMState = orm.session().state;
+const defaultAssetsState = {};
 const defaultAPIState = {};
 
 function getTimestamps(modelName, entry) {
@@ -94,6 +95,13 @@ export default combineReducers({
       return session.state;
     },
   }, defaultORMState),
+
+  assets: handleActions({
+    [RECEIVE_ASSET]: (state, action) => ({
+      ...state,
+      [action.payload.key]: action.payload.asset,
+    }),
+  }, defaultAssetsState),
 
   api: handleActions({
     [FETCH_DATA]: (state, action) => ({

--- a/src/state/ducks/orm/selectors.js
+++ b/src/state/ducks/orm/selectors.js
@@ -214,5 +214,11 @@ export const recentMediaItemsSelector = createSelector(
   },
 );
 
+// Contentful URLs don't have a url scheme for some reason.
+export const assetUrlSelector = (state, key) => {
+  const url = _.get(state, `orm.assets.${key}.fields.file.url`);
+  return url ? `https:${url}` : null;
+};
+
 export const apiLoadingSelector = (state, resource) => _.get(state, ['orm.api.loading', resource], false);
 export const apiErrorSelector = state => _.get(state, 'orm.api.error');

--- a/src/state/ducks/orm/types.js
+++ b/src/state/ducks/orm/types.js
@@ -1,5 +1,7 @@
 import { scopedType } from '../../utils';
 
 export const FETCH_DATA = scopedType('orm/FETCH_DATA');
+export const FETCH_ASSET = scopedType('orm/FETCH_ASSET');
 export const RECEIVE_DATA = scopedType('orm/RECEIVE_DATA');
+export const RECEIVE_ASSET = scopedType('orm/RECEIVE_ASSET');
 export const RECEIVE_API_ERROR = scopedType('orm/RECEIVE_API_ERROR');


### PR DESCRIPTION
## Description
Adds all-the-redux-things for **assets**, allowing us to put them in Contentful and
load them in the app, with the ability to change them in Contentful without having to
change the app.

Exclusively intended for assets that aren't otherwise associated with a
model. Currently just the "All Meditations" cover image, but easy to add other
assets with fixed IDs.

## Screenshots
![Screen Shot 2019-03-19 at 8 23 05 AM](https://user-images.githubusercontent.com/91550/54606003-f917b480-4a20-11e9-8aa3-cbdc85668876.png)
