### PR TITLE
Persist playback state

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prelint": "yarn generate-default-config",
     "pretest": "yarn generate-default-config",
     "preci:deploy": "yarn generate-default-config",
-    "prestorybook": "rnstl"
+    "prestorybook": "rnstl",
+    "postinstall": "rndebugger-open --expo"
   },
   "dependencies": {
     "@expo/vector-icons": "^8.0.0",
@@ -49,6 +50,7 @@
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
+    "redux-devtools-extension": "^2.13.8",
     "redux-observable": "^0.17.0",
     "redux-orm": "^0.11.0",
     "redux-persist": "^5.10.0",
@@ -83,7 +85,7 @@
     "pluralize": "^7.0.0",
     "pre-commit": "^1.2.2",
     "react-dom": "16.0.0-beta.5",
-    "react-native-debugger-open": "^0.3.15",
+    "react-native-debugger-open": "^0.3.19",
     "react-native-storybook-loader": "^1.7.0",
     "react-test-renderer": "16.0.0-beta.5",
     "reactotron-react-native": "^3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^0.18.0",
     "axios-retry": "^3.1.2",
     "contentful": "^7.1.0",
+    "cycle": "^1.0.3",
     "expo": "^31.0.4",
     "html-entities": "^1.2.1",
     "is-html": "^1.1.0",

--- a/src/Root.js
+++ b/src/Root.js
@@ -17,8 +17,6 @@ console.tron = Reactotron;
 
 
 if (config.sentryPublicDSN) {
-  // Remove this once Sentry is correctly setup.
-  Sentry.enableInExpoDevelopment = true;
   Sentry.config(config.sentryPublicDSN).install();
 }
 

--- a/src/components/PlayableItemHeader.js
+++ b/src/components/PlayableItemHeader.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 import moment from 'moment';
 import { ViewPropTypes, View, Text, StyleSheet } from 'react-native';
+import momentPropTypes from 'react-moment-proptypes';
 
 import PlayButton from './PlayButton';
 import SquareImage from './SquareImage';
-import { formatMinutesString, screenRelativeWidth } from './utils';
+import {
+  formatFooter,
+  formatMinutesString,
+  formatHumanizeFromNow,
+  screenRelativeWidth,
+} from './utils';
 
 import AppPropTypes from '../propTypes';
 
@@ -34,26 +39,13 @@ const styles = StyleSheet.create({
   },
 });
 
-function formatFooter({
-  duration, publishedAt, formatDuration, formatPublishedAt,
-}) {
-  const separator = ' • ';
-  const strings = [];
-  if (!_.isNull(duration)) {
-    strings.push(formatDuration(duration));
-  }
-  if (!_.isNull(publishedAt)) {
-    strings.push(formatPublishedAt(publishedAt));
-  }
-  return strings.join(separator);
-}
-
 const PlayableItemHeader = ({
   coverImageSource,
   style,
   title,
   duration,
   publishedAt,
+  elapsed,
   onPlay,
   formatDuration,
   formatPublishedAt,
@@ -70,7 +62,7 @@ const PlayableItemHeader = ({
       <Text style={styles.title} numberOfLines={2}>{title}</Text>
       <Text style={styles.times}>
         {formatFooter({
-          duration, publishedAt, formatDuration, formatPublishedAt,
+          duration, elapsed, publishedAt, formatDuration, formatPublishedAt,
         })}
       </Text>
       <PlayButton onPress={onPlay} text="Listen" />
@@ -84,6 +76,7 @@ PlayableItemHeader.propTypes = {
   title: PropTypes.string.isRequired,
   duration: PropTypes.string,
   publishedAt: PropTypes.string,
+  elapsed: momentPropTypes.momentDurationObj,
   onPlay: PropTypes.func,
   formatDuration: PropTypes.func,
   formatPublishedAt: PropTypes.func,
@@ -93,9 +86,10 @@ PlayableItemHeader.defaultProps = {
   style: {},
   duration: null,
   publishedAt: null,
+  elapsed: moment.duration(),
   onPlay: () => {},
   formatDuration: formatMinutesString,
-  formatPublishedAt: publishedAt => `${moment(publishedAt).fromNow()}`,
+  formatPublishedAt: formatHumanizeFromNow,
 };
 
 export default PlayableItemHeader;

--- a/src/components/PlayableListCard.js
+++ b/src/components/PlayableListCard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import moment from 'moment';
 import {
   View,
   ViewPropTypes,
@@ -18,7 +17,7 @@ import ListCard from './ListCard';
 import SquareImage from './SquareImage';
 import TextPill from './TextPill';
 import { renderDescription } from './ItemDescription';
-import { formatMinutesString } from './utils';
+import { formatFooter, formatMinutesString } from './utils';
 import * as navActions from '../navigation/actions';
 
 import appPropTypes from '../propTypes';
@@ -106,23 +105,6 @@ const styles = StyleSheet.create({
   },
 });
 
-export function formatFooter({
-  duration,
-  publishedAt,
-  formatDuration: fmt,
-}) {
-  const separator = ' • ';
-  const strings = [];
-  const formatDuration = fmt || formatMinutesString;
-  if (duration) {
-    strings.push(formatDuration(duration));
-  }
-  if (!_.isUndefined(publishedAt)) {
-    strings.push(moment(publishedAt).fromNow());
-  }
-  return strings.join(separator);
-}
-
 function accessStyle({ patronsOnly, isFreePreview }) {
   return (!patronsOnly || isFreePreview) ? {} : {
     opacity: 0.5,
@@ -151,6 +133,7 @@ const PlayableListCard = ({
   isSearchResult,
   navigation,
   item,
+  elapsed,
   canAccess,
   onPlay,
   ...props
@@ -179,7 +162,7 @@ const PlayableListCard = ({
         <View style={styles.searchHeader}>
           <TextPill style={styles.mediaType}>{pluralize.singular(item.type)}</TextPill>
           <Text style={styles.times}>
-            {formatFooter({ ...item, formatDuration })}
+            {formatFooter({ ...item, elapsed, formatDuration })}
           </Text>
         </View>
       ) : null}
@@ -208,7 +191,7 @@ const PlayableListCard = ({
       {isSearchResult ? null : (
         <View style={styles.footer}>
           <Text style={styles.times}>
-            {formatFooter({ ...item, formatDuration })}
+            {formatFooter({ ...item, elapsed, formatDuration })}
           </Text>
         </View>
       )}
@@ -220,6 +203,7 @@ PlayableListCard.propTypes = {
   style: ViewPropTypes.style,
   navigation: appPropTypes.navigation.isRequired,
   item: appPropTypes.mediaItem.isRequired,
+  elapsed: PropTypes.string,
   formatDuration: PropTypes.func,
   isSearchResult: PropTypes.bool,
   canAccess: PropTypes.bool.isRequired,
@@ -229,6 +213,7 @@ PlayableListCard.propTypes = {
 
 PlayableListCard.defaultProps = {
   style: {},
+  elapsed: 'P0D',
   formatDuration: formatMinutesString,
   isSearchResult: false,
 };

--- a/src/components/PodcastEpisodeListCard.js
+++ b/src/components/PodcastEpisodeListCard.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
+import { connect } from 'react-redux';
+
 import PlayableListCard from './PlayableListCard';
-
 import PodcastEpisode from '../state/models/PodcastEpisode';
+import * as playbackSelectors from '../state/ducks/playback/selectors';
 
-const PodcastEpisodeListCard = ({ episode, ...props }) => (
+const PodcastEpisodeListCard = ({ episode, elapsed, ...props }) => (
   <PlayableListCard
     item={episode}
+    elapsed={elapsed}
     {...props}
   />
 );
@@ -15,6 +19,16 @@ PodcastEpisodeListCard.propTypes = {
   episode: PropTypes.shape(
     PodcastEpisode.propTypes,
   ).isRequired,
+  elapsed: PropTypes.string.isRequired,
 };
 
-export default PodcastEpisodeListCard;
+function mapStateToProps(state, { episode }) {
+  const { id } = episode;
+  const status = playbackSelectors.getLastStatusForItem(state, id);
+  const elapsed = status ? moment.duration(status.positionMillis, 'ms') : moment.duration();
+  return {
+    elapsed: elapsed.toString(),
+  };
+}
+
+export default connect(mapStateToProps)(PodcastEpisodeListCard);

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,11 +1,37 @@
 import { Dimensions } from 'react-native';
 import moment from 'moment';
+import _ from 'lodash';
 
-export function formatMinutesString(durationStr) {
-  const momentObj = moment.duration(durationStr);
+export function formatMinutesString(durationStr, elapsed = moment.duration()) {
+  const momentObj = moment.duration(durationStr).subtract(elapsed);
   const minutes = Math.round(momentObj.asMinutes());
   const suffix = minutes === 1 ? '' : 's';
-  return `${minutes} minute${suffix}`;
+  const remaining = elapsed.asSeconds() > 0 ? ' remaining' : '';
+  return `${minutes} minute${suffix}${remaining}`;
+}
+
+export function formatHumanizeFromNow(publishedAt) {
+  return `${moment(publishedAt).fromNow()}`;
+}
+
+export function formatFooter({
+  duration,
+  elapsed,
+  publishedAt,
+  formatDuration: _formatDuration,
+  formatPublishedAt: _formatPublishedAt,
+}) {
+  const separator = ' • ';
+  const strings = [];
+  const formatDuration = _formatDuration || formatMinutesString;
+  const formatPublishedAt = _formatPublishedAt || formatHumanizeFromNow;
+  if (duration) {
+    strings.push(formatDuration(duration, moment.duration(elapsed)));
+  }
+  if (!_.isUndefined(publishedAt)) {
+    strings.push(formatPublishedAt(publishedAt));
+  }
+  return strings.join(separator);
 }
 
 export function screenRelativeWidth(fraction) {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import moment from 'moment';
 import {
   Image,
   Text,
@@ -20,8 +21,8 @@ import * as navActions from '../navigation/actions';
 import { recentMediaItemsSelector } from '../state/ducks/orm/selectors';
 import { getImageSource } from '../state/ducks/orm/utils';
 import { fetchData } from '../state/ducks/orm/actions';
-import { screenRelativeWidth, screenRelativeHeight } from '../components/utils';
-import { formatFooter } from '../components/PlayableListCard';
+import * as playbackSelectors from '../state/ducks/playback/selectors';
+import { screenRelativeWidth, screenRelativeHeight, formatFooter } from '../components/utils';
 
 const styles = StyleSheet.create({
   container: {
@@ -127,7 +128,15 @@ HomeScreen.navigationOptions = ({ screenProps }) => ({
 
 function mapStateToProps(state) {
   return {
-    items: recentMediaItemsSelector(state),
+    items: recentMediaItemsSelector(state).map(
+      (item) => {
+        const status = playbackSelectors.getLastStatusForItem(state, item.id);
+        if (status) {
+          return _.set(item, 'elapsed', moment.duration(status.positionMillis, 'ms'));
+        }
+        return item;
+      },
+    ),
   };
 }
 

--- a/src/screens/PlayerScreen/Controls.js
+++ b/src/screens/PlayerScreen/Controls.js
@@ -66,8 +66,9 @@ const PlaybackButton = ({
   style,
   playButtonIconStyle,
   pauseButtonIconStyle,
+  disabled,
 }) => (
-  <TouchableWithoutFeedback onPress={onPress}>
+  <TouchableWithoutFeedback onPress={onPress} disabled={disabled}>
     <View style={[styles.playbackButton, style]}>
       {
         isPaused
@@ -84,12 +85,14 @@ PlaybackButton.propTypes = {
   style: ViewPropTypes.style,
   playButtonIconStyle: appPropTypes.iconStyle,
   pauseButtonIconStyle: appPropTypes.iconStyle,
+  disabled: PropTypes.bool,
 };
 
 PlaybackButton.defaultProps = {
   style: {},
   playButtonIconStyle: {},
   pauseButtonIconStyle: {},
+  disabled: false,
 };
 
 const JumpIcon = ({
@@ -124,9 +127,11 @@ let JumpButton = ({
   jumpSeconds,
   jump,
   iconStyle,
+  disabled,
 }) => (
   <TouchableWithoutFeedback
     onPress={() => { jump(jumpSeconds); }}
+    disabled={disabled}
   >
     <View>
       <JumpIcon style={iconStyle} jumpSeconds={jumpSeconds} />
@@ -138,10 +143,12 @@ JumpButton.propTypes = {
   jumpSeconds: PropTypes.number.isRequired,
   jump: PropTypes.func.isRequired,
   iconStyle: appPropTypes.iconStyle,
+  disabled: PropTypes.bool,
 };
 
 JumpButton.defaultProps = {
   iconStyle: {},
+  disabled: false,
 };
 
 JumpButton = connect(null, actions)(JumpButton);
@@ -155,6 +162,7 @@ const Controls = ({
   play,
   pause,
   style,
+  disabled,
   jumpButtonStyle,
   jumpButtonIconStyle,
   playbackButtonStyle,
@@ -166,7 +174,7 @@ const Controls = ({
       style={jumpButtonStyle}
       iconStyle={jumpButtonIconStyle}
       jumpSeconds={-jumpSeconds}
-      disabled={!item}
+      disabled={disabled}
     />
     <PlaybackButton
       style={playbackButtonStyle}
@@ -174,13 +182,13 @@ const Controls = ({
       pauseButtonIconStyle={pauseButtonIconStyle}
       isPaused={isPaused}
       onPress={() => (isPaused ? play(item) : pause(item))}
-      disabled={!item}
+      disabled={disabled}
     />
     <JumpButton
       style={jumpButtonStyle}
       iconStyle={jumpButtonIconStyle}
       jumpSeconds={jumpSeconds}
-      disabled={!item}
+      disabled={disabled}
     />
   </View>
 );
@@ -190,6 +198,7 @@ Controls.propTypes = {
   isPaused: PropTypes.bool.isRequired,
   play: PropTypes.func.isRequired,
   pause: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
   style: ViewPropTypes.style,
   jumpButtonStyle: ViewPropTypes.style,
   playbackButtonStyle: ViewPropTypes.style,
@@ -212,6 +221,7 @@ function mapStateToProps(state) {
   return {
     item: selectors.item(state),
     isPaused: selectors.isPaused(state),
+    disabled: !selectors.item(state) || !selectors.getSound(state),
   };
 }
 

--- a/src/screens/SingleMediaItemScreen.js
+++ b/src/screens/SingleMediaItemScreen.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import moment from 'moment';
 import { ScrollView, View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import { withNavigation } from 'react-navigation';
+import momentPropTypes from 'react-moment-proptypes';
 
 import appPropTypes from '../propTypes';
 import PlayableItemHeader from '../components/PlayableItemHeader';
@@ -13,6 +15,7 @@ import SocialLinksSection from '../components/SocialLinksSection';
 import TagList from '../components/TagList';
 
 import * as playbackActions from '../state/ducks/playback/actions';
+import * as playbackSelectors from '../state/ducks/playback/selectors';
 import { getImageSource } from '../state/ducks/orm/utils';
 
 const padding = 15;
@@ -35,7 +38,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const SingleMediaItemScreen = ({ item, play }) => (
+const SingleMediaItemScreen = ({ item, elapsed, play }) => (
   <ScrollView style={styles.container}>
     <View style={styles.subContainer}>
       <PlayableItemHeader
@@ -43,6 +46,7 @@ const SingleMediaItemScreen = ({ item, play }) => (
         title={item.title}
         description={item.description}
         duration={item.duration}
+        elapsed={elapsed}
         publishedAt={item.publishedAt}
         onPlay={() => play()}
       />
@@ -61,8 +65,15 @@ const SingleMediaItemScreen = ({ item, play }) => (
 
 SingleMediaItemScreen.propTypes = {
   item: appPropTypes.mediaItem.isRequired,
+  elapsed: momentPropTypes.momentDurationObj.isRequired,
   play: PropTypes.func.isRequired,
 };
+
+function mapStateToProps(state, { item }) {
+  const status = playbackSelectors.getLastStatusForItem(state, item.id);
+  const elapsed = status ? moment.duration(status.positionMillis, 'ms') : moment.duration();
+  return { elapsed };
+}
 
 function mapDispatchToProps(dispatch, { navigation, item }) {
   return {
@@ -79,5 +90,5 @@ function mapDispatchToProps(dispatch, { navigation, item }) {
 
 
 export default withNavigation(
-  connect(null, mapDispatchToProps)(SingleMediaItemScreen),
+  connect(mapStateToProps, mapDispatchToProps)(SingleMediaItemScreen),
 );

--- a/src/state/ducks/orm/epic.js
+++ b/src/state/ducks/orm/epic.js
@@ -85,7 +85,7 @@ function catchApiError(retryAction) {
       error,
     });
 
-    if (retryAction && error.response.status === 401) {
+    if (retryAction && _.get(error, 'response.status') === 401) {
       // Patreon token has expired; try (once) to refresh it,
       // then retry the related action
       return Observable.of(

--- a/src/state/ducks/playback/actions.js
+++ b/src/state/ducks/playback/actions.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { createAction } from 'redux-actions';
 
 import * as types from './types';
@@ -6,8 +7,12 @@ import * as types from './types';
  * Set the provided item to be playing.
  *
  * @param {PodcastEpisode|Meditation} item media item to play
+ * @param {bool} shouldPlay if true (default), playback will start immediately
  */
-export const setPlaying = createAction(types.SET_PLAYING);
+export const setPlaying = createAction(
+  types.SET_PLAYING,
+  (item, shouldPlay = true) => ({ ..._.pick(item, ['type', 'id']), shouldPlay }),
+);
 
 /**
  * Store the created Sound for later reference.

--- a/src/state/ducks/playback/actions.js
+++ b/src/state/ducks/playback/actions.js
@@ -2,9 +2,28 @@ import { createAction } from 'redux-actions';
 
 import * as types from './types';
 
+/**
+ * Set the provided item to be playing.
+ *
+ * @param {PodcastEpisode|Meditation} item media item to play
+ */
 export const setPlaying = createAction(types.SET_PLAYING);
+
+/**
+ * Store the created Sound for later reference.
+ *
+ * @param {Expo.Audio.Sound} sound sound returned from Sound.createAsync
+ */
 export const setSound = createAction(types.SET_SOUND);
+
+/**
+ * Start playback.
+ */
 export const play = createAction(types.PLAY);
+
+/**
+ * Pause playback.
+ */
 export const pause = createAction(types.PAUSE);
 
 /**

--- a/src/state/ducks/playback/epic.js
+++ b/src/state/ducks/playback/epic.js
@@ -43,7 +43,9 @@ const startPlayingEpic = (action$, store) =>
         prevSound.stopAsync();
       }
 
-      return startPlayback(item);
+      const initialStatus = selectors.getLastStatusForItem(state, id);
+
+      return startPlayback(item, initialStatus);
     }),
   );
 

--- a/src/state/ducks/playback/reducer.js
+++ b/src/state/ducks/playback/reducer.js
@@ -74,8 +74,8 @@ export default persistReducer(
   handleActions({
     [SET_PLAYING]: (state, action) => ({
       ...state,
-      item: action.payload,
-      paused: false,
+      item: _.pick(action.payload, ['type', 'id']),
+      paused: !_.get(action.payload, 'shouldPlay', true),
     }),
     [SET_SOUND]: (state, action) => ({
       ...state,

--- a/src/state/ducks/playback/reducer.js
+++ b/src/state/ducks/playback/reducer.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+
 import { handleActions } from '../../utils/reduxActions';
 
 import {
@@ -13,13 +14,19 @@ import {
 /* playback reducer state shape:
 {
   // current item playing, if any
-  item: Meditation,
+  item: PodcastEpisode|Meditation,
 
   // true iff something has started playback
   playing: boolean,
 
   // true iff playback is paused
   paused: boolean,
+
+  // time elapsed in playback
+  elapsed: moment.Duration,
+
+  // playing sound object
+  sound: Expo.Audio.Sound,
 
   // status of playing item
   status: Expo.Audio.Sound.status,
@@ -31,7 +38,24 @@ const defaultState = {
   playing: false,
   paused: false,
   elapsed: moment.duration(),
+  sound: null,
+  status: null,
 };
+
+// define here alongside state; used at top level
+export const playbackTransform = [
+  inboundState => ({
+    ...inboundState,
+    playing: false,
+    sound: null,
+    paused: true,
+    elapsed: inboundState.elapsed.toString(),
+  }),
+  outboundState => ({
+    ...outboundState,
+    elapsed: moment.duration(outboundState.elapsed),
+  }),
+];
 
 export default handleActions({
   [SET_PLAYING]: (state, action) => ({

--- a/src/state/ducks/playback/reducer.js
+++ b/src/state/ducks/playback/reducer.js
@@ -18,9 +18,6 @@ import {
   // current item playing, if any
   item: PodcastEpisode|Meditation,
 
-  // true iff something has started playback
-  playing: boolean,
-
   // true iff playback is paused
   paused: boolean,
 
@@ -34,7 +31,6 @@ import {
 
 const defaultState = {
   item: null,
-  playing: false,
   paused: false,
   sound: null,
   status: null,
@@ -45,11 +41,6 @@ export const playbackTransforms = [
     () => null, // clear sound
     outboundState => outboundState,
     { whitelist: ['sound'] },
-  ),
-  createTransform(
-    () => false, // pause playback
-    outboundState => outboundState,
-    { whitelist: ['playing'] },
   ),
   createTransform(
     () => true, // pause playback
@@ -65,7 +56,7 @@ const persistConfig = {
 };
 
 function storePodcastEpisodePlaybackStatus(playbackStatusPerItem, item, status) {
-  if (item.type !== 'podcastEpisode') {
+  if (!item || item.type !== 'podcastEpisode') {
     return playbackStatusPerItem;
   }
 
@@ -73,15 +64,9 @@ function storePodcastEpisodePlaybackStatus(playbackStatusPerItem, item, status) 
     ...playbackStatusPerItem,
     [item.id]: {
       ..._.get(playbackStatusPerItem, item.id, {}),
-      status,
+      ...status,
     },
   };
-}
-
-function setInitialStatus(state, item) {
-  const { id } = item;
-  const status = _.get(state.playbackStatusPerItem, id);
-  return status ? { status } : {};
 }
 
 export default persistReducer(
@@ -90,9 +75,7 @@ export default persistReducer(
     [SET_PLAYING]: (state, action) => ({
       ...state,
       item: action.payload,
-      playing: true,
       paused: false,
-      ...setInitialStatus(state, action.payload),
     }),
     [SET_SOUND]: (state, action) => ({
       ...state,
@@ -100,7 +83,6 @@ export default persistReducer(
     }),
     [PLAY]: state => ({
       ...state,
-      playing: true,
       paused: false,
     }),
     [PAUSE]: state => ({

--- a/src/state/ducks/playback/reducer.js
+++ b/src/state/ducks/playback/reducer.js
@@ -47,6 +47,16 @@ export const playbackTransform = [
   outboundState => outboundState,
 ];
 
+function storePodcastEpisodePlaybackStatus(item, status) {
+  if (item.type !== 'podcastEpisode') {
+    return {};
+  }
+
+  return {
+    [item.id]: status,
+  };
+}
+
 export default handleActions({
   [SET_PLAYING]: (state, action) => ({
     ...state,
@@ -70,6 +80,10 @@ export default handleActions({
   [SET_STATUS]: (state, action) => ({
     ...state,
     status: action.payload,
+    playbackStatusPerItem: {
+      ...state.playbackStatusPerItem,
+      ...storePodcastEpisodePlaybackStatus(state.item, action.payload),
+    },
     item: action.payload.didJustFinish ? null : state.item,
   }),
   [SET_PENDING_SEEK]: (state, action) => ({

--- a/src/state/ducks/playback/reducer.js
+++ b/src/state/ducks/playback/reducer.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 import { handleActions } from '../../utils/reduxActions';
 
 import {
@@ -22,9 +20,6 @@ import {
   // true iff playback is paused
   paused: boolean,
 
-  // time elapsed in playback
-  elapsed: moment.Duration,
-
   // playing sound object
   sound: Expo.Audio.Sound,
 
@@ -37,7 +32,6 @@ const defaultState = {
   item: null,
   playing: false,
   paused: false,
-  elapsed: moment.duration(),
   sound: null,
   status: null,
 };
@@ -49,12 +43,8 @@ export const playbackTransform = [
     playing: false,
     sound: null,
     paused: true,
-    elapsed: inboundState.elapsed.toString(),
   }),
-  outboundState => ({
-    ...outboundState,
-    elapsed: moment.duration(outboundState.elapsed),
-  }),
+  outboundState => outboundState,
 ];
 
 export default handleActions({

--- a/src/state/ducks/playback/selectors.js
+++ b/src/state/ducks/playback/selectors.js
@@ -31,6 +31,10 @@ export function getStatus(state) {
   return state.playback.status;
 }
 
+export function getLastStatusForItem(state, id) {
+  return _.get(state.playback.playbackStatusPerItem, id, {});
+}
+
 export function elapsed(state) {
   if (state.playback.pendingSeekDestination) {
     return state.playback.pendingSeekDestination;

--- a/src/state/ducks/playback/selectors.js
+++ b/src/state/ducks/playback/selectors.js
@@ -11,10 +11,6 @@ export function item(state) {
   return instanceSelector(state, type, id);
 }
 
-export function isPlaying(state) {
-  return state.playback.playing;
-}
-
 export function isPaused(state) {
   return state.playback.paused;
 }

--- a/src/state/ducks/playback/test.js
+++ b/src/state/ducks/playback/test.js
@@ -1,1 +1,158 @@
-test('placeholder', () => {});
+import { Observable } from 'rxjs';
+
+import configureStore from '../../store';
+
+import { SET_SOUND } from './types';
+import { setPlaying, setStatus } from './actions';
+import { getStatus, getLastStatusForItem } from './selectors';
+import epic from './epic';
+import { receiveData } from '../orm/actions';
+
+
+jest.mock('expo', () => {
+  class Sound {
+    constructor(...args) {
+      const [source, initialStatus, onPlaybackStatusUpdate] = args;
+      Object.assign(this, { source, initialStatus, onPlaybackStatusUpdate });
+    }
+
+    stopAsync() {
+      const status = { isPlaying: false, positionMillis: 0 };
+      this.updateStatusAsync(status);
+      // XXX: should probably return a promise, but we don't need it yet
+    }
+
+    updateStatusAsync(status) {
+      // for testing; force status updates, but with some control
+      setTimeout(() => this.onPlaybackStatusUpdate(status), 0);
+    }
+
+    static createAsync(...args) {
+      return Promise.resolve({ sound: new Sound(...args) });
+    }
+  }
+
+  return {
+    ...jest.requireActual('expo'),
+    Audio: {
+      Sound,
+    },
+  };
+});
+
+describe('playback reducer', () => {
+  let store;
+
+  beforeEach(() => {
+    ({ store } = configureStore({ noEpic: true }));
+  });
+
+  test('setStatus() stores current and per-item status', () => {
+    const item = { type: 'podcastEpisode', id: '42' };
+    const status = { positionMillis: 42000 };
+    store.dispatch(setPlaying(item));
+    store.dispatch(setStatus(status));
+
+    const state = store.getState();
+    expect(getStatus(state)).toEqual(status);
+    expect(getLastStatusForItem(state, item.id)).toEqual(status);
+  });
+});
+
+describe('playback epic', () => {
+  const items = [
+    {
+      type: 'podcastEpisode',
+      id: '42',
+    },
+    {
+      type: 'podcastEpisode',
+      id: '43',
+    },
+  ];
+  const itemApiData = items.map(
+    item => ({
+      sys: {
+        id: item.id,
+        contentType: {
+          sys: {
+            id: item.type,
+          },
+        },
+      },
+      fields: {
+        mediaUrl: 'https://httpbin.org/get',
+      },
+    }),
+  );
+
+  let store;
+  let inputAction$;
+  let action$;
+  let subscriber;
+
+  beforeEach(async () => {
+    ({ store } = configureStore({ noEpic: true }));
+    const apiActions = items.map((item, i) => (
+      receiveData({
+        resource: item.type,
+        id: item.id,
+        json: itemApiData[i],
+      })
+    ));
+    apiActions.forEach(apiAction => store.dispatch(apiAction));
+
+    const playAction = setPlaying(items[0]);
+    store.dispatch(playAction);
+
+    // Note: we make this multicast via share(). Otherwise, it's only the _last_
+    // subscriber that receives events, and each epic in combineEpics(...)
+    // subscribes to this observable in sequence.
+    inputAction$ = Observable.create((s) => {
+      subscriber = s;
+      subscriber.next(playAction);
+    }).share();
+
+    action$ = epic(inputAction$, store);
+  });
+
+  test('emits setStatus actions during playback', (done) => {
+    let count = 0;
+    const status = { isPlaying: true, foo: 'bar' };
+    const secondStatus = { isPlaying: true, foo: 'baz' };
+    action$.subscribe((action) => {
+      const assertions = [
+        () => {
+          expect(action.type).toEqual(SET_SOUND);
+          store.dispatch(action);
+          const sound = action.payload;
+          expect(sound).toBeDefined();
+          sound.updateStatusAsync(status);
+        },
+        () => {
+          expect(action).toEqual(setStatus(status));
+          store.dispatch(action);
+
+          const playAction = setPlaying(items[1]);
+
+          subscriber.next(playAction);
+
+          store.dispatch(playAction);
+        },
+        () => {
+          expect(action.type).toEqual(SET_SOUND);
+          store.dispatch(action);
+          const sound = action.payload;
+          expect(sound).toBeDefined();
+          sound.updateStatusAsync(secondStatus);
+        },
+        () => {
+          expect(action).toEqual(setStatus(secondStatus));
+          done();
+        },
+      ];
+      assertions[count]();
+      count += 1;
+    });
+  });
+});

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { createStore, applyMiddleware, compose } from 'redux';
 import { combineEpics, createEpicMiddleware } from 'redux-observable';
-import { persistReducer, persistStore, createMigrate } from 'redux-persist';
+import { persistReducer, persistStore, createMigrate, createTransform } from 'redux-persist';
 import storage from 'redux-persist/lib/storage'; // AsyncStorage for react-native
 
 import { Observable } from 'rxjs';
@@ -11,6 +11,7 @@ import Reactotron from '../../reactotron-config';
 
 import reducer from './reducer';
 import epics from './epics';
+import { playbackTransform } from './ducks/playback/reducer';
 
 const migrations = {
   0: state => ({
@@ -22,12 +23,18 @@ const migrations = {
   }),
 };
 
+const PlaybackTransform = createTransform(
+  ...playbackTransform,
+  { whitelist: ['playback'] },
+);
+
 const persistConfig = {
   key: 'root',
   storage,
-  blacklist: ['auth', 'playback'],
+  blacklist: ['auth'],
   version: 0,
   migrate: createMigrate(migrations),
+  transforms: [PlaybackTransform],
 };
 const persistedReducer = persistReducer(persistConfig, reducer);
 

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import { createStore, applyMiddleware, compose } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import { combineEpics, createEpicMiddleware } from 'redux-observable';
 import { persistReducer, persistStore, createMigrate, createTransform } from 'redux-persist';
 import storage from 'redux-persist/lib/storage'; // AsyncStorage for react-native
@@ -57,7 +58,7 @@ export default function configureStore({ noEpic = false } = {}) {
 
   const store = createStore(
     persistedReducer,
-    compose(
+    composeWithDevTools(
       enhancer,
       Reactotron.createEnhancer(),
     ),

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import { combineEpics, createEpicMiddleware } from 'redux-observable';
-import { persistReducer, persistStore, createMigrate, createTransform } from 'redux-persist';
+import { persistReducer, persistStore, createMigrate } from 'redux-persist';
 import storage from 'redux-persist/lib/storage'; // AsyncStorage for react-native
 
 import { Observable } from 'rxjs';
@@ -12,7 +12,6 @@ import Reactotron from '../../reactotron-config';
 
 import reducer from './reducer';
 import epics from './epics';
-import { playbackTransform } from './ducks/playback/reducer';
 
 const migrations = {
   0: state => ({
@@ -24,18 +23,12 @@ const migrations = {
   }),
 };
 
-const PlaybackTransform = createTransform(
-  ...playbackTransform,
-  { whitelist: ['playback'] },
-);
-
 const persistConfig = {
   key: 'root',
   storage,
-  blacklist: ['auth'],
+  blacklist: ['auth', 'playback'],
   version: 0,
   migrate: createMigrate(migrations),
-  transforms: [PlaybackTransform],
 };
 const persistedReducer = persistReducer(persistConfig, reducer);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3721,6 +3721,11 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
   integrity sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==
 
+cycle@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
+  integrity sha1-IegLK+hYD5i0aPN5QwZisEbDStI=
+
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9706,10 +9706,10 @@ react-native-compat@^1.0.0:
   dependencies:
     prop-types "^15.5.10"
 
-react-native-debugger-open@^0.3.15:
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/react-native-debugger-open/-/react-native-debugger-open-0.3.17.tgz#85b1b0dd76b0025d6f7c16a7c161b9d30a9bae93"
-  integrity sha512-wNWn5wPjdZTLTbdFBKNNwvIJqnWK4ejMbg0fbZRwpQPYyJqexaEm0TjTvCY4wk210Ag6Rr9vrLZH+dcwZMdMrg==
+react-native-debugger-open@^0.3.19:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/react-native-debugger-open/-/react-native-debugger-open-0.3.19.tgz#d34af49cb871db5161fa46b4b5d24d01b22755a1"
+  integrity sha512-C564fBgUj365/rI5lEBDGUPXwWnw95t2pO3bLz36uXLoqrYTQS2z5cBUErm9P0mJop0s/bxy2YZqzqHlbE43Tw==
   dependencies:
     chalk "^1.1.3"
     es6-template "^1.0.4"
@@ -10238,6 +10238,11 @@ redux-actions@^2.2.1:
     loose-envify "^1.4.0"
     reduce-reducers "^0.4.3"
     to-camel-case "^1.0.0"
+
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
 
 redux-observable@^0.17.0:
   version "0.17.0"


### PR DESCRIPTION
## Description
- Save a portion of the playback state
  - Restores currently-playing item on rehydrate
- Save the playback state per-item for podcast episodes
  - Restores the playback state for each episode individually, even if it wasn't the most recently playing
- New unit tests for the playback epic
  - Super rough. I'm finding it quite tricky to unit test RxJS code, but I'm starting to get my head around it. Should revisit in the future.

## Motivation and Context
Closes #132.

## How Has This Been Tested?
- New unit tests pass
- Verified that playback status is saved for podcast episodes
  - Loaded a podcast episode
  - Seeked to the middle
  - Loaded another episode
  - Seeked to the middle
  - Switch back to the previous episode
  - Observe saved playback position
  - Repeat
- Verified that playback status is restored on rehydrate
  - Same steps as above, but starting by reloading the app