### PR TITLE
Implement contributor screen and search screen

### DIFF
--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -7,8 +7,6 @@ import Card from './Card';
 const styles = StyleSheet.create({
   card: {
     padding: 10,
-    marginHorizontal: 7,
-    marginVertical: 7,
   },
 });
 

--- a/src/components/PersonCard.js
+++ b/src/components/PersonCard.js
@@ -11,6 +11,7 @@ import {
 
 import AppPropTypes from '../propTypes';
 import CircleImage from './CircleImage';
+import { getImageSource } from '../state/ducks/orm/utils';
 
 const shadowRadius = 6;
 
@@ -53,7 +54,7 @@ const PersonCard = ({ person, onPress, style }) => (
   <TouchableWithoutFeedback onPress={onPress}>
     <View style={[styles.card, style]}>
       <CircleImage
-        source={{ uri: person.imageUrl }}
+        source={getImageSource(person)}
         diameter={70}
         style={styles.picture}
       />

--- a/src/components/PersonList.js
+++ b/src/components/PersonList.js
@@ -5,6 +5,7 @@ import { View, ScrollView, StyleSheet } from 'react-native';
 import AppPropTypes from '../propTypes';
 import PersonCard from './PersonCard';
 import SectionHeader from './SectionHeader';
+import TextPill from './TextPill';
 
 const styles = StyleSheet.create({
   list: {
@@ -13,6 +14,12 @@ const styles = StyleSheet.create({
   },
   card: {
     marginHorizontal: 5,
+  },
+  header: {
+    flexDirection: 'row',
+  },
+  headerText: {
+    marginRight: 6,
   },
 
   // pad the end of the list, inside the ScrollView,
@@ -26,7 +33,10 @@ const styles = StyleSheet.create({
 
 const PersonList = ({ people, onPressPerson }) => (
   <View>
-    <SectionHeader>People</SectionHeader>
+    <View style={styles.header}>
+      <SectionHeader style={styles.headerText}>People</SectionHeader>
+      <TextPill>{`${people.length}`}</TextPill>
+    </View>
     <ScrollView horizontal style={styles.list}>
       {people.map(person => (
         <PersonCard

--- a/src/components/SectionHeader.js
+++ b/src/components/SectionHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet, ViewPropTypes } from 'react-native';
 
 const styles = StyleSheet.create({
   header: {
@@ -10,14 +10,19 @@ const styles = StyleSheet.create({
   },
 });
 
-const SectionHeader = ({ children }) => (
-  <Text style={styles.header}>
+const SectionHeader = ({ style, children }) => (
+  <Text style={[styles.header, style]}>
     {children}
   </Text>
 );
 
 SectionHeader.propTypes = {
+  style: ViewPropTypes.style,
   children: PropTypes.string.isRequired,
+};
+
+SectionHeader.defaultProps = {
+  style: {},
 };
 
 export default SectionHeader;

--- a/src/components/TextPill.js
+++ b/src/components/TextPill.js
@@ -10,7 +10,7 @@ import {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#D2D2D2',
+    backgroundColor: '#797979',
     borderRadius: 8,
     paddingHorizontal: 6,
     paddingVertical: 2,

--- a/src/components/TextPill.js
+++ b/src/components/TextPill.js
@@ -12,12 +12,15 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: '#D2D2D2',
     borderRadius: 8,
-    paddingHorizontal: 8,
-    paddingVertical: 3,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   text: {
     color: '#FFFFFF',
     fontSize: 10,
+    fontWeight: '500',
   },
 });
 

--- a/src/navigation/MainNavigator.js
+++ b/src/navigation/MainNavigator.js
@@ -16,6 +16,8 @@ import SinglePodcastEpisodeScreen from '../screens/SinglePodcastEpisodeScreen';
 import MeditationsScreen from '../screens/MeditationsScreen';
 import MeditationsCategoryScreen from '../screens/MeditationsCategoryScreen';
 import SingleMeditationScreen from '../screens/SingleMeditationScreen';
+import ContributorScreen from '../screens/ContributorScreen';
+import SearchResultsScreen from '../screens/SearchResultsScreen';
 import DrawerContent from '../navigation/DrawerContent';
 import MeditationsIcon from '../screens/MeditationsIcon';
 import PodcastsIcon from '../screens/PodcastsIcon';
@@ -37,11 +39,9 @@ const PodcastsNavigator = createStackNavigator({
   Podcasts: PodcastsScreen,
   Podcast: PodcastScreen,
   SinglePodcastEpisode: SinglePodcastEpisodeScreen,
-}, {
-  navigationOptions: {
-    tabBarIcon: MeditationsIcon,
-  },
-});
+  Contributor: ContributorScreen,
+  SearchResults: SearchResultsScreen,
+}, {});
 
 PodcastsNavigator.navigationOptions = {
   tabBarIcon: PodcastsIcon,
@@ -51,11 +51,9 @@ const MeditationsNavigator = createStackNavigator({
   AllMeditationCategories: MeditationsScreen,
   MeditationsCategory: MeditationsCategoryScreen,
   SingleMeditation: SingleMeditationScreen,
-}, {
-  navigationOptions: {
-    tabBarIcon: MeditationsIcon,
-  },
-});
+  Contributor: ContributorScreen,
+  SearchResults: SearchResultsScreen,
+}, {});
 
 MeditationsNavigator.navigationOptions = {
   tabBarIcon: MeditationsIcon,

--- a/src/screens/ContributorScreen/Bio.js
+++ b/src/screens/ContributorScreen/Bio.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StyleSheet, Text, View } from 'react-native';
+
+import Button from '../../components/Button';
+import Contributor from '../../state/models/Contributor';
+
+const styles = StyleSheet.create({
+  bio: {},
+  bioTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#9B9B9B',
+  },
+  bioBody: {
+    color: '#4A4A4A',
+    fontSize: 15,
+    lineHeight: 20,
+    marginVertical: 10,
+  },
+  bioButton: {
+    height: 44,
+    alignSelf: 'auto',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  bioButtonText: {
+    fontWeight: '600',
+    color: '#797979',
+    fontSize: 15,
+  },
+});
+
+class Bio extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      expanded: false,
+    };
+  }
+
+  render() {
+    const { contributor } = this.props;
+    const { expanded } = this.state;
+    return (
+      <View style={styles.bio}>
+        <Text style={styles.bioTitle}>About</Text>
+        <Text style={styles.bioBody} numberOfLines={expanded ? null : 10}>
+          {contributor.bio}
+        </Text>
+        <Button
+          style={styles.bioButton}
+          onPress={() => this.setState({ expanded: !expanded })}
+        >
+          <Text style={styles.bioButtonText}>
+            {`${expanded ? 'Hide' : 'View'} Full Bio`}
+          </Text>
+        </Button>
+      </View>
+    );
+  }
+}
+
+Bio.propTypes = {
+  contributor: PropTypes.shape(Contributor.proptypes).isRequired,
+};
+
+export default Bio;

--- a/src/screens/ContributorScreen/Contributions.js
+++ b/src/screens/ContributorScreen/Contributions.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StyleSheet, Text, View, ViewPropTypes } from 'react-native';
+import { connect } from 'react-redux';
+import { withNavigation } from 'react-navigation';
+
+import Button from '../../components/Button';
+import Contributor from '../../state/models/Contributor';
+import { getTitle } from '../SearchResultsScreen';
+import { filteredCollectionSelector } from '../../state/ducks/orm/selectors';
+import TextPill from '../../components/TextPill';
+import PlayableListCard from '../../components/PlayableListCard';
+import { screenRelativeWidth } from '../../components/utils';
+import appPropTypes from '../../propTypes';
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'flex-start',
+    marginVertical: 13,
+  },
+  titleContainer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    marginVertical: 10,
+  },
+  title: {
+    color: '#9B9B9B',
+    fontSize: 18,
+    fontWeight: '600',
+    marginRight: 6,
+  },
+  items: {
+    width: screenRelativeWidth(1.0) - 34,
+  },
+  card: {
+    marginVertical: 7,
+  },
+  button: {
+    height: 44,
+    alignSelf: 'stretch',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  buttonText: {
+    fontWeight: '600',
+    color: '#797979',
+    fontSize: 15,
+  },
+});
+
+const typeTitles = {
+  podcastEpisode: 'Podcasts',
+  meditation: 'Meditations',
+};
+
+const maxEntries = 3;
+
+const Contributions = ({
+  style, type, contributor, items, viewAll,
+}) => (
+  <View style={[styles.container, style]}>
+    <View style={styles.titleContainer}>
+      <Text style={styles.title}>{typeTitles[type]}</Text>
+      <TextPill>{`${items.length}`}</TextPill>
+    </View>
+    <View style={styles.items}>
+      {
+        items.slice(0, maxEntries).map(
+          item => <PlayableListCard key={item.id} style={styles.card} item={item} />,
+        )
+      }
+    </View>
+    <Button
+      style={styles.button}
+      onPress={() => viewAll()}
+    >
+      <Text style={styles.buttonText}>
+        {`View All ${getTitle({ type, contributor })}`}
+      </Text>
+    </Button>
+  </View>
+);
+
+Contributions.propTypes = {
+  // contributor is used in mapStateToProps, but not directly in rendering.
+  // eslint-disable-next-line
+  contributor: PropTypes.shape(Contributor.propTypes).isRequired,
+  style: ViewPropTypes.style,
+  type: PropTypes.oneOf(Object.keys(typeTitles)).isRequired,
+  items: PropTypes.arrayOf(
+    appPropTypes.mediaItem.isRequired,
+  ).isRequired,
+  viewAll: PropTypes.func.isRequired,
+};
+
+Contributions.defaultProps = {
+  style: {},
+};
+
+function makeMapStateToProps(factoryState, { contributor, type }) {
+  const selector = filteredCollectionSelector(
+    factoryState,
+    type,
+
+    // only return items with the specified contributor
+    item => item.contributors.filter(contributor).count() > 0,
+  );
+  return function mapStateToProps(state) {
+    return {
+      items: selector(state),
+    };
+  };
+}
+
+function mapDispatchToProps(dispatch, { contributor, type, navigation }) {
+  return {
+    viewAll: () => navigation.navigate({
+      routeName: 'SearchResults',
+      params: { contributor, type },
+    }),
+  };
+}
+
+export default withNavigation(
+  connect(makeMapStateToProps, mapDispatchToProps)(Contributions),
+);

--- a/src/screens/ContributorScreen/Socials.js
+++ b/src/screens/ContributorScreen/Socials.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Linking, StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
+import { Entypo } from '@expo/vector-icons';
+
+import Contributor from '../../state/models/Contributor';
+
+const styles = StyleSheet.create({
+  socials: {
+    flexDirection: 'row',
+    marginVertical: 10,
+  },
+  socialButton: {
+    fontSize: 22,
+    color: '#8A8A8F',
+    paddingHorizontal: 10,
+  },
+});
+
+const getIconName = service => (service === 'website' ? 'globe' : service);
+
+const SocialButton = ({ contributor, service }) => (
+  <TouchableWithoutFeedback onPress={() => Linking.openURL(contributor[service])}>
+    <Entypo name={getIconName(service)} style={styles.socialButton} />
+  </TouchableWithoutFeedback>
+);
+
+const services = ['website', 'twitter', 'facebook', 'instagram'];
+
+SocialButton.propTypes = {
+  contributor: PropTypes.shape(Contributor.propTypes).isRequired,
+  service: PropTypes.oneOf(services).isRequired,
+};
+
+const Socials = ({ contributor }) => (
+  <View style={styles.socials}>
+    {
+      services.filter(
+        service => !!contributor[service],
+      ).map(
+        service => <SocialButton key={service} contributor={contributor} service={service} />,
+      )
+    }
+  </View>
+);
+
+Socials.propTypes = {
+  contributor: PropTypes.shape(Contributor.proptypes).isRequired,
+};
+
+export default Socials;

--- a/src/screens/ContributorScreen/index.js
+++ b/src/screens/ContributorScreen/index.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { connect } from 'react-redux';
+
+import Socials from './Socials';
+import Bio from './Bio';
+import Contributions from './Contributions';
+import CircleImage from '../../components/CircleImage';
+import BackButton from '../../navigation/BackButton';
+import Contributor from '../../state/models/Contributor';
+import { contributorSelector } from '../../state/ducks/orm/selectors';
+import { getImageSource } from '../../state/ducks/orm/utils';
+import { screenRelativeWidth } from '../../components/utils';
+
+const diameter = 148;
+const backdropWidth = screenRelativeWidth(3);
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+  },
+  backdrop: {
+    backgroundColor: '#F95A57',
+    height: backdropWidth,
+    width: backdropWidth,
+    borderRadius: backdropWidth,
+    position: 'absolute',
+    top: (diameter * 1.25) - backdropWidth,
+  },
+  image: {
+    position: 'absolute',
+    top: diameter * 0.75,
+  },
+  details: {
+    alignItems: 'center',
+    marginTop: diameter * 1.85,
+    marginHorizontal: 17,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 3,
+  },
+  title: {
+    color: '#8A8A8F',
+    fontSize: 13,
+  },
+  organization: {
+    color: '#8A8A8F',
+    fontSize: 13,
+  },
+  contributionsContainer: {
+    alignItems: 'flex-start',
+    paddingHorizontal: 17,
+    width: '100%',
+  },
+});
+
+/**
+ * Single contributor screen with bio and media.
+ */
+const ContributorScreen = ({ contributor }) => (
+  <ScrollView contentContainerStyle={styles.container}>
+    <View style={styles.backdrop} />
+    <CircleImage
+      source={getImageSource(contributor)}
+      diameter={diameter}
+      style={styles.image}
+      shadow
+    />
+    <View style={styles.details}>
+      <Text style={styles.name}>{contributor.name}</Text>
+      <Text style={styles.title}>{contributor.title}</Text>
+      <Text style={styles.organization}>{contributor.organization}</Text>
+      <Socials contributor={contributor} />
+      <Bio contributor={contributor} />
+    </View>
+    <View style={styles.contributionsContainer}>
+      <Contributions type="podcastEpisode" contributor={contributor} />
+      <Contributions type="meditation" contributor={contributor} />
+    </View>
+  </ScrollView>
+);
+
+ContributorScreen.propTypes = {
+  contributor: PropTypes.shape(Contributor.propTypes).isRequired,
+};
+
+function makeMapStateToProps(state, { navigation }) {
+  const { state: { params: { contributor } } } = navigation;
+  return function mapStateToProps() {
+    return {
+      contributor: contributorSelector(state, contributor.id),
+    };
+  };
+}
+
+ContributorScreen.navigationOptions = () => ({
+  headerLeft: <BackButton />,
+  title: '',
+  headerTransparent: true,
+});
+
+export default connect(makeMapStateToProps)(ContributorScreen);

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -43,9 +43,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     marginBottom: screenRelativeHeight(0.01),
   },
-  mediaType: {
-    backgroundColor: '#797979',
-  },
   title: {
     fontSize: 24,
     fontWeight: '600',
@@ -96,7 +93,7 @@ class HomeScreen extends React.Component {
                   source={getImageSource(item, true)}
                 />
                 <View style={styles.mediaTypeContainer}>
-                  <TextPill style={styles.mediaType}>
+                  <TextPill>
                     {item.type.replace('Episode', '')}
                   </TextPill>
                 </View>

--- a/src/screens/MeditationsCategoryScreen.js
+++ b/src/screens/MeditationsCategoryScreen.js
@@ -19,6 +19,10 @@ const styles = StyleSheet.create({
   container: {
     paddingVertical: 7,
   },
+  card: {
+    marginHorizontal: 14,
+    marginVertical: 7,
+  },
 });
 
 /**
@@ -36,7 +40,7 @@ const MeditationsCategoryScreen = ({
     data={meditations}
     keyExtractor={item => item.id}
     renderItem={
-      ({ item: meditation }) => <MeditationListCard meditation={meditation} />
+      ({ item: meditation }) => <MeditationListCard style={styles.card} meditation={meditation} />
     }
   />
 );

--- a/src/screens/PodcastScreen.js
+++ b/src/screens/PodcastScreen.js
@@ -15,6 +15,10 @@ const styles = StyleSheet.create({
   container: {
     paddingVertical: 7,
   },
+  card: {
+    marginHorizontal: 14,
+    marginVertical: 7,
+  },
 });
 
 /**
@@ -32,7 +36,7 @@ const PodcastScreen = ({
     data={episodes}
     keyExtractor={item => item.id}
     renderItem={
-      ({ item: episode }) => <PodcastEpisodeListCard episode={episode} />
+      ({ item: episode }) => <PodcastEpisodeListCard style={styles.card} episode={episode} />
     }
   />
 );

--- a/src/screens/SearchResultsScreen.js
+++ b/src/screens/SearchResultsScreen.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { FlatList, StyleSheet } from 'react-native';
+import pluralize from 'pluralize';
+
+import { getCommonNavigationOptions } from '../navigation/common';
+import BackButton from '../navigation/BackButton';
+import PlayableListCard from '../components/PlayableListCard';
+import { filteredCollectionSelector, apiLoadingSelector } from '../state/ducks/orm/selectors';
+import { fetchData } from '../state/ducks/orm';
+import appPropTypes from '../propTypes';
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 7,
+  },
+  card: {
+    marginHorizontal: 14,
+    marginVertical: 7,
+  },
+});
+
+/**
+ * List of episodes in podcast, sorted by publish date.
+ */
+const SearchResultsScreen = ({
+  items,
+  refreshing,
+  refresh,
+}) => (
+  <FlatList
+    style={styles.container}
+    refreshing={refreshing}
+    onRefresh={() => refresh()}
+    data={items}
+    keyExtractor={item => item.id}
+    renderItem={
+      ({ item }) => <PlayableListCard style={styles.card} item={item} />
+    }
+  />
+);
+
+SearchResultsScreen.propTypes = {
+  items: PropTypes.arrayOf(
+    appPropTypes.mediaItem.isRequired,
+  ).isRequired,
+  refreshing: PropTypes.bool.isRequired,
+  refresh: PropTypes.func.isRequired,
+};
+
+function getParams(navigation) {
+  const { state: { params } } = navigation;
+  return params;
+}
+
+function makeMapStateToProps(factoryState, { navigation }) {
+  const { type, contributor } = getParams(navigation);
+  const selector = filteredCollectionSelector(
+    factoryState,
+    type,
+    item => item.contributors.filter(contributor).count() > 0,
+  );
+
+  return function mapStateToProps(state) {
+    return {
+      items: selector(state),
+      refreshing: (
+        apiLoadingSelector(state, pluralize(type))
+      ),
+    };
+  };
+}
+
+function mapDispatchToProps(dispatch, { type }) {
+  return {
+    refresh: () => {
+      dispatch(
+        fetchData({
+          resource: type,
+        }),
+      );
+    },
+  };
+}
+
+export function getTitle({ type, contributor }) {
+  // for now, search results are limited to links from contributor screens,
+  // so we're keeping the title simple and informative based on that.
+  const title = {
+    podcastEpisode: 'Podcasts',
+    meditation: 'Meditations',
+  }[type];
+  const firstName = contributor.name.split(' ')[0];
+  return `${title} with ${firstName}`;
+}
+
+SearchResultsScreen.navigationOptions = ({ screenProps, navigation }) => ({
+  ...getCommonNavigationOptions(screenProps.drawer),
+  headerLeft: <BackButton />,
+  title: getTitle(getParams(navigation)),
+});
+
+export default connect(makeMapStateToProps, mapDispatchToProps)(SearchResultsScreen);

--- a/src/screens/SingleMediaItemScreen.js
+++ b/src/screens/SingleMediaItemScreen.js
@@ -36,7 +36,9 @@ const styles = StyleSheet.create({
   },
 });
 
-const SingleMediaItemScreen = ({ item, elapsed, play }) => (
+const SingleMediaItemScreen = ({
+  item, elapsed, play, navigation,
+}) => (
   <ScrollView style={styles.container}>
     <View style={styles.subContainer}>
       <PlayableItemHeader item={item} elapsed={elapsed} onPlay={() => play()} />
@@ -44,7 +46,13 @@ const SingleMediaItemScreen = ({ item, elapsed, play }) => (
       <ItemDescription description={item.description} />
     </View>
     <View style={styles.peopleContainer}>
-      <PersonList people={item.contributors} />
+      <PersonList
+        people={item.contributors}
+        onPressPerson={(person) => {
+          const params = { contributor: person };
+          navigation.navigate({ routeName: 'Contributor', params });
+        }}
+      />
     </View>
     <View style={styles.subContainer}>
       <TagList tags={item.tags} />
@@ -57,6 +65,7 @@ SingleMediaItemScreen.propTypes = {
   item: appPropTypes.mediaItem.isRequired,
   elapsed: momentPropTypes.momentDurationObj.isRequired,
   play: PropTypes.func.isRequired,
+  navigation: appPropTypes.navigation.isRequired,
 };
 
 function mapStateToProps(state, { item }) {

--- a/src/state/ducks/orm/selectors.js
+++ b/src/state/ducks/orm/selectors.js
@@ -182,6 +182,21 @@ export function collectionSelector(state, type) {
   return collectionSelectors[type](state);
 }
 
+export function filteredCollectionSelector(state, type, filterFunc = () => true) {
+  const modelName = getModelName(type);
+  const selector = createSelector(
+    orm,
+    dbStateSelector,
+    session => session[modelName].all()
+      .orderBy(...modelOrderArgs[modelName])
+      .toModelArray()
+      .filter(filterFunc)
+      .map(modelToObject[modelName])
+      .map(obj => ({ ...obj, type })),
+  );
+  return selector;
+}
+
 export function instanceSelector(state, type, id) {
   return instanceSelectors[type](state, id);
 }

--- a/src/state/models/Contributor.js
+++ b/src/state/models/Contributor.js
@@ -10,8 +10,12 @@ Contributor.modelName = 'Contributor';
 
 Contributor.fields = {
   name: attr(),
-  url: attr(),
+  title: attr(),
+  organization: attr(),
+  bio: attr(),
+  website: attr(),
   imageUrl: attr(),
+  image: attr(),
   twitter: attr(),
   facebook: attr(),
   createdAt: attr(),
@@ -20,8 +24,12 @@ Contributor.fields = {
 
 Contributor.propTypes = {
   name: PropTypes.string,
-  url: PropTypes.string,
+  title: PropTypes.string,
+  organization: PropTypes.string,
+  bio: PropTypes.string,
+  website: PropTypes.string,
   imageUrl: PropTypes.string,
+  image: PropTypes.string,
   twitter: PropTypes.string,
   facebook: PropTypes.string,
   createdAt: PropTypes.string,

--- a/storybook/storybook.js
+++ b/storybook/storybook.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { createSwitchNavigator } from 'react-navigation';
+import { createSwitchNavigator, createAppContainer } from 'react-navigation';
 import { getStorybookUI, configure } from '@storybook/react-native';
 
 import { loadStories } from './storyLoader';
@@ -23,6 +23,8 @@ const StorybookNavigator = createSwitchNavigator({
   Storybook: { screen: StorybookScreen },
 });
 
+const StorybookContainer = createAppContainer(StorybookNavigator);
+
 // This assumes that storybook is running on the same host as your RN packager,
 // to set manually use, e.g. host: 'localhost' option
 const StorybookUIRoot = getStorybookUI({ port: 7007, onDeviceUI: true });
@@ -33,7 +35,7 @@ const StorybookUIRoot = getStorybookUI({ port: 7007, onDeviceUI: true });
 class StorybookUIHMRRoot extends Component {
   render() {
     return (
-      <StorybookNavigator />
+      <StorybookContainer />
     );
   }
 }


### PR DESCRIPTION
## Description
Search screen is currently limited to related links from the contributor screen,
but it can likely be extended to support general searching as well. Perhaps.
(Or we might decide to implement that separately.)

Also added a count indicator on the people list itself.

I'm not wild about the transparent header when content is scrolled up, as it conflicts with the clock and status bar. Leaving that for general design tweaks later, though.

## Motivation and Context
Closes #116 and closes #129.

## How Has This Been Tested?
Added contributors to things in Contentful; navigated all around through different paths. Noticed that the Patreon content restriction works the same as in the podcast/meditation category listing screens.