### PR TITLE
Add RSS feed buttons for podcasts and meditation categories

### DIFF
--- a/src/components/FeedButton.js
+++ b/src/components/FeedButton.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Alert, Clipboard, StyleSheet, TouchableOpacity } from 'react-native';
+import Icon from '@expo/vector-icons/Entypo';
+
+import * as authSelectors from '../state/ducks/auth/selectors';
+import config from '../../config.json';
+
+const styles = StyleSheet.create({
+  icon: {
+    fontSize: 24,
+    height: 30,
+    paddingHorizontal: 20,
+  },
+});
+
+function copyFeed(url) {
+  Clipboard.setString(url);
+  Alert.alert(
+    'Feed URL Copied',
+    'You can now paste this URL into your favorite podcast app.',
+    [{ text: 'OK' }],
+  );
+}
+
+const FeedButton = ({ url }) => (
+  url ? (
+    <TouchableOpacity onPress={() => copyFeed(url)}>
+      <Icon
+        name="rss"
+        style={styles.icon}
+      />
+    </TouchableOpacity>
+  ) : null
+);
+
+FeedButton.propTypes = {
+  collection: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    feedUrl: PropTypes.string,
+  }).isRequired,
+  url: PropTypes.string,
+};
+
+FeedButton.defaultProps = {
+  url: null,
+};
+
+function mapStateToProps(state, { collection }) {
+  let url;
+  if (collection.feedUrl) {
+    url = collection.feedUrl;
+  } else {
+    const token = authSelectors.token(state);
+    if (token) {
+      const { type, id } = collection;
+      url = `${config.apiBaseUrl}/rss/${type}/${id}?token=${token}`;
+    }
+  }
+
+  return { url };
+}
+
+export default connect(mapStateToProps)(FeedButton);

--- a/src/navigation/BackButton.js
+++ b/src/navigation/BackButton.js
@@ -8,7 +8,7 @@ import appPropTypes from '../propTypes';
 const styles = StyleSheet.create({
   backIcon: {
     fontSize: 36,
-    paddingHorizontal: 10,
+    paddingHorizontal: 20,
   },
 });
 

--- a/src/navigation/MenuButton.js
+++ b/src/navigation/MenuButton.js
@@ -7,7 +7,7 @@ import Icon from '@expo/vector-icons/MaterialIcons';
 const styles = StyleSheet.create({
   menuIcon: {
     fontSize: 24,
-    paddingHorizontal: 10,
+    paddingHorizontal: 20,
   },
 });
 

--- a/src/screens/MeditationsCategoryScreen.js
+++ b/src/screens/MeditationsCategoryScreen.js
@@ -5,6 +5,7 @@ import { FlatList, StyleSheet } from 'react-native';
 
 import { getCommonNavigationOptions } from '../navigation/common';
 import BackButton from '../navigation/BackButton';
+import FeedButton from '../components/FeedButton';
 import MeditationListCard from '../components/MeditationListCard';
 import Meditation from '../state/models/Meditation';
 import {
@@ -56,8 +57,13 @@ MeditationsCategoryScreen.defaultProps = {
   meditations: [],
 };
 
-function mapStateToProps(state, { navigation }) {
+function getCategory(navigation) {
   const { state: { params: { category } } } = navigation;
+  return category;
+}
+
+function mapStateToProps(state, { navigation }) {
+  const category = getCategory(navigation);
   const meditations = (
     category.title === 'All Meditations'
       ? meditationsSelector(state)
@@ -87,6 +93,7 @@ function mapDispatchToProps(dispatch) {
 MeditationsCategoryScreen.navigationOptions = ({ screenProps, navigation }) => ({
   ...getCommonNavigationOptions(screenProps.drawer),
   headerLeft: <BackButton />,
+  headerRight: <FeedButton collection={getCategory(navigation)} onPress={() => {}} />,
   title: navigation.state.params.category.title,
 });
 

--- a/src/screens/MeditationsScreen.js
+++ b/src/screens/MeditationsScreen.js
@@ -32,6 +32,8 @@ class MeditationsScreen extends Component {
       {
         title: 'All Meditations',
         imageUrl: allMeditationsCoverArtUrl,
+        type: 'meditationCategory',
+        id: 'all',
       },
       ...categories,
     ];
@@ -76,7 +78,9 @@ MeditationsScreen.defaultProps = {
 function mapStateToProps(state) {
   return {
     meditations: meditationsSelector(state),
-    categories: meditationCategoriesSelector(state),
+    categories: meditationCategoriesSelector(state).filter(
+      category => category.meditations.length > 0,
+    ),
     allMeditationsCoverArtUrl: assetUrlSelector(state, ALL_MEDITATIONS_COVER_ART),
     refreshing: apiLoadingSelector(state, 'meditations'),
   };

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -109,7 +109,6 @@ const patronUpsell = newPatronPitch
 
 
 const PatreonStatus = ({
-  isConnected,
   isPatron,
   patronFirstName,
   pledge,
@@ -117,7 +116,7 @@ const PatreonStatus = ({
 }) => (
   <View style={styles.status}>
     <Text style={styles.heading}>
-      {isConnected ? `Hello ${patronFirstName}!` : 'Become a Patron'}
+      {isPatron ? `Hello ${patronFirstName}!` : 'Become a Patron'}
     </Text>
     <Text style={styles.text}>
       {isPatron ? currentPatreonText : newPatronText}
@@ -154,7 +153,6 @@ const PatreonStatus = ({
 );
 
 PatreonStatus.propTypes = {
-  isConnected: PropTypes.bool.isRequired,
   isPatron: PropTypes.bool.isRequired,
   patronFirstName: PropTypes.string.isRequired,
   pledge: PropTypes.shape({
@@ -188,9 +186,15 @@ PatreonError.defaultProps = {
   error: null,
 };
 
-const PatreonButton = ({ title, onPress, opacity }) => (
+const PatreonButton = ({
+  title,
+  onPress,
+  opacity,
+  disabled,
+}) => (
   <TouchableOpacity
     onPress={onPress}
+    disabled={disabled}
   >
     <ImageBackground
       source={patreonButton}
@@ -206,17 +210,18 @@ PatreonButton.propTypes = {
   title: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   opacity: PropTypes.number,
+  disabled: PropTypes.bool,
 };
 
 PatreonButton.defaultProps = {
   opacity: 1.0,
+  disabled: false,
 };
 
 const PatreonConnectButton = ({
   isConnected,
   connect: connectPatreon,
   disconnect,
-  fetchData,
 }) => {
   const title = isConnected ? 'Disconnect Patreon' : 'Connect with Patreon';
   const onPress = (
@@ -231,9 +236,6 @@ const PatreonConnectButton = ({
             style: 'destructive',
             onPress: () => {
               disconnect();
-              fetchData({ resource: 'podcastEpisode' });
-              fetchData({ resource: 'meditation' });
-              fetchData({ resource: 'liturgyItem' });
             },
           },
         ],
@@ -255,22 +257,24 @@ PatreonConnectButton.propTypes = {
   isConnected: PropTypes.bool.isRequired,
   connect: PropTypes.func.isRequired,
   disconnect: PropTypes.func.isRequired,
-  fetchData: PropTypes.func.isRequired,
 };
 
 const PatreonRefreshButton = ({
   isConnected,
   getDetails,
   fetchData,
+  loading,
 }) => (
   isConnected ?
     <PatreonButton
-      title="Refresh Patron Status"
+      title={loading ? 'Refreshing...' : 'Refresh Patron Status'}
+      disabled={loading}
+      opacity={loading ? 0.75 : 1.0}
       onPress={() => {
         getDetails();
-        fetchData({ resource: 'podcastEpisode' });
-        fetchData({ resource: 'meditation' });
-        fetchData({ resource: 'liturgyItem' });
+        ['podcastEpisode', 'meditation', 'liturgyItem'].forEach(
+          resource => fetchData({ resource }),
+        );
       }}
     />
     : null
@@ -280,6 +284,7 @@ PatreonRefreshButton.propTypes = {
   isConnected: PropTypes.bool.isRequired,
   getDetails: PropTypes.func.isRequired,
   fetchData: PropTypes.func.isRequired,
+  loading: PropTypes.bool.isRequired,
 };
 
 const PatreonScreen = props => (

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -263,7 +263,7 @@ const PatreonRefreshButton = ({
   getDetails,
   fetchData,
 }) => (
-  isConnected &&
+  isConnected ?
     <PatreonButton
       title="Refresh Patron Status"
       onPress={() => {
@@ -273,6 +273,7 @@ const PatreonRefreshButton = ({
         fetchData({ resource: 'liturgyItem' });
       }}
     />
+    : null
 );
 
 PatreonRefreshButton.propTypes = {

--- a/src/screens/PodcastScreen.js
+++ b/src/screens/PodcastScreen.js
@@ -5,6 +5,7 @@ import { FlatList, StyleSheet } from 'react-native';
 
 import { getCommonNavigationOptions } from '../navigation/common';
 import BackButton from '../navigation/BackButton';
+import FeedButton from '../components/FeedButton';
 import PodcastEpisodeListCard from '../components/PodcastEpisodeListCard';
 import PodcastEpisode from '../state/models/PodcastEpisode';
 import { podcastSelector, apiLoadingSelector } from '../state/ducks/orm/selectors';
@@ -52,8 +53,13 @@ PodcastScreen.defaultProps = {
   episodes: [],
 };
 
-function mapStateToProps(state, { navigation }) {
+function getPodcast(navigation) {
   const { state: { params: { podcast } } } = navigation;
+  return podcast;
+}
+
+function mapStateToProps(state, { navigation }) {
+  const podcast = getPodcast(navigation);
   const { episodes } = podcastSelector(state, podcast.id);
   return {
     episodes,
@@ -78,6 +84,7 @@ function mapDispatchToProps(dispatch) {
 PodcastScreen.navigationOptions = ({ screenProps, navigation }) => ({
   ...getCommonNavigationOptions(screenProps.drawer),
   headerLeft: <BackButton />,
+  headerRight: <FeedButton collection={getPodcast(navigation)} />,
   title: navigation.state.params.podcast.title,
 });
 

--- a/src/screens/PodcastsScreen.js
+++ b/src/screens/PodcastsScreen.js
@@ -60,7 +60,7 @@ PodcastsScreen.defaultProps = {
 
 function mapStateToProps(state) {
   return {
-    podcasts: podcastsSelector(state),
+    podcasts: podcastsSelector(state).filter(podcast => podcast.episodes.length > 0),
     refreshing: apiLoadingSelector(state, 'podcasts'),
   };
 }

--- a/src/state/ducks/auth/reducer.js
+++ b/src/state/ducks/auth/reducer.js
@@ -25,7 +25,7 @@ export default persistReducer(
   persistConfig,
   handleActions({
     [patreonTypes.STORE_TOKEN]: (state, action) => ({
-      patreonToken: action.payload,
+      ...action.payload,
     }),
     [patreonTypes.DISCONNECT]: () => ({
       patreonToken: null,

--- a/src/state/ducks/auth/selectors.js
+++ b/src/state/ducks/auth/selectors.js
@@ -1,3 +1,7 @@
+export function token(state) {
+  return state.auth.liturgistsToken;
+}
+
 export function isAuthenticated(state) {
-  return state.auth.authenticated;
+  return !!token(state);
 }

--- a/src/state/ducks/orm/epic.js
+++ b/src/state/ducks/orm/epic.js
@@ -14,8 +14,7 @@ import parse from 'url-parse';
 
 import { FETCH_DATA, FETCH_ASSET } from './types';
 import { receiveData, receiveAsset, receiveApiError, ALL_MEDITATIONS_COVER_ART } from './actions';
-import * as patreonActions from '../patreon/actions';
-import * as patreonSelectors from '../patreon/selectors';
+import * as authSelectors from '../auth/selectors';
 import config from '../../../../config.json';
 import showError from '../../../showError';
 
@@ -65,29 +64,15 @@ function getAsset(client, key) {
 }
 
 function patreonAuthHeader(state) {
-  const token = patreonSelectors.token(state);
+  const token = authSelectors.token(state);
   return token ? {
-    'x-theliturgists-patreon-token': token,
+    'x-theliturgists-token': token,
   } : {};
 }
 
-function catchApiError(retryAction) {
+function catchApiError() {
   return catchError((error) => {
-    const errorAction = receiveApiError({
-      ..._.pick(retryAction.payload, ['resource', 'id', 'collection']),
-      error,
-    });
-
-    if (retryAction && _.get(error, 'response.status') === 401) {
-      // Patreon token has expired; try (once) to refresh it,
-      // then retry the related action
-      return of(
-        patreonActions.refreshAccessToken({
-          retryAction,
-          errorAction,
-        }),
-      );
-    }
+    const errorAction = receiveApiError({ error });
 
     showError(error);
     return of(errorAction);

--- a/src/state/ducks/orm/test.js
+++ b/src/state/ducks/orm/test.js
@@ -12,8 +12,6 @@ import { getModelName, getRelationships } from './utils';
 import epic from './epic';
 import { getStateObservable } from '../testUtils';
 
-import * as patreonActions from '../patreon/actions';
-
 jest.mock('contentful/dist/contentful.browser');
 
 function contentType(type) {
@@ -528,35 +526,6 @@ describe('api epic', () => {
 
       expect(errorAction.type).toEqual(types.RECEIVE_API_ERROR);
       expect(errorAction.payload.error).toBeInstanceOf(Error);
-    });
-  });
-
-  describe('when Patreon token is expired', () => {
-    const error = new Error('patreon token expired');
-
-    beforeEach(() => {
-      _.set(error, 'response.status', 401);
-
-      // XXX: hack.
-      contentful.__setError(error);
-    });
-
-    test('fetchData() leads to refreshAccessToken()', async () => {
-      const args = { resource: 'foo' };
-      const retryAction = actions.fetchData(args);
-      const errorAction = actions.receiveApiError({
-        resource: 'foo',
-        error,
-      });
-
-      const action$ = ActionsObservable.of(retryAction);
-      const refreshAction = await epic(action$, getStateObservable(store)).toPromise();
-
-      const expectedAction = patreonActions.refreshAccessToken({
-        retryAction,
-        errorAction,
-      });
-      expect(expectedAction).toEqual(refreshAction);
     });
   });
 });

--- a/src/state/ducks/patreon/reducer.js
+++ b/src/state/ducks/patreon/reducer.js
@@ -40,7 +40,6 @@ export default handleActions({
   }),
   [STORE_TOKEN]: state => ({
     ...state,
-    loading: false,
   }),
   [GET_DETAILS]: state => ({
     ...state,

--- a/src/state/ducks/patreon/selectors.js
+++ b/src/state/ducks/patreon/selectors.js
@@ -2,17 +2,10 @@ import _ from 'lodash';
 import { JsonApiDataStore } from 'jsonapi-datastore';
 
 import { CAMPAIGN_URL } from './constants';
-
-export function token(state) {
-  return _.get(state.auth.patreonToken, 'access_token');
-}
-
-export function refreshToken(state) {
-  return _.get(state.auth.patreonToken, 'refresh_token');
-}
+import * as authSelectors from '../auth/selectors';
 
 export function isConnected(state) {
-  return !!token(state);
+  return authSelectors.isAuthenticated(state);
 }
 
 export function getPledge(state) {

--- a/src/state/ducks/patreon/test.js
+++ b/src/state/ducks/patreon/test.js
@@ -1,17 +1,7 @@
-import { ActionsObservable } from 'redux-observable';
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-
 import configureStore from '../../store';
 // import * as types from './types';
 import * as actions from './actions';
 import * as selectors from './selectors';
-import epic from './epic';
-import { getStateObservable } from '../testUtils';
-
-import config from '../../../../config.json';
-
-const mock = new MockAdapter(axios);
 
 /*
  * Reducers are tested by stubbing out the epic with one that does nothing,
@@ -28,7 +18,7 @@ const mock = new MockAdapter(axios);
 
 describe('patreon reducer', () => {
   let store;
-  const token = { access_token: 'foo', refresh_token: 'bar' };
+  const token = { liturgistsToken: 'foo' };
 
   beforeEach(() => {
     ({ store } = configureStore({ noEpic: true }));
@@ -63,60 +53,4 @@ describe('patreon reducer', () => {
 
 describe('patreon epic', () => {
   // TODO: mock patreon auth and test epic
-
-  describe('refreshAccessToken()', () => {
-    const retryAction = { type: 'FOO' };
-    const errorAction = { type: 'BAR' };
-    const action = actions.refreshAccessToken({
-      retryAction,
-      errorAction,
-    });
-    let action$;
-    let store;
-
-    let patreonMock;
-
-    beforeEach(() => {
-      ({ store } = configureStore({ noEpic: true }));
-      action$ = ActionsObservable.of(action);
-      patreonMock = mock.onPost(`${config.apiBaseUrl}/patreon/validate`);
-    });
-
-    afterEach(() => {
-      mock.reset();
-    });
-
-    test('leads to retry action if refresh succeeds', async () => {
-      const patreonAuth = {
-        access_token: 'foo',
-        refresh_token: 'bar',
-      };
-      const newPatreonAuth = {
-        access_token: 'baz',
-        refresh_token: 'quux',
-      };
-      store.dispatch(actions.storeToken(patreonAuth));
-      patreonMock.reply(200, newPatreonAuth);
-
-      const resultAction = await epic(action$, getStateObservable(store)).toPromise();
-      expect(resultAction).toEqual(retryAction);
-    });
-
-    test('leads to error action if refresh fails', async () => {
-      const patreonAuth = {
-        access_token: 'foo',
-        refresh_token: 'bar',
-      };
-      store.dispatch(actions.storeToken(patreonAuth));
-      patreonMock.reply(401, {});
-
-      const resultAction = await epic(action$, getStateObservable(store)).toPromise();
-      expect(resultAction).toEqual(errorAction);
-    });
-
-    test("leads to error action if there's no refresh token", async () => {
-      const resultAction = await epic(action$, getStateObservable(store)).toPromise();
-      expect(resultAction).toEqual(errorAction);
-    });
-  });
 });


### PR DESCRIPTION
## Description
- RSS feed buttons on each podcast and meditation category
  - Button generates URL pointed at our backend, copies it to the clipboard
- Migrate from Patreon token to Liturgists token
  - Prompts user to re-auth if anything goes wrong on the Patreon side
  - Backend handles Patreon token expiration and refresh, as well as mapping Patreon user ID to Liturgists token (for connecting new devices)

## Motivation and Context
Closes #115.

## How Has This Been Tested?
- Feeds:
  - Loaded feeds for podcasts and meditation categories in podcast players (see theliturgists/backend#6) and in feed validators
- Patreon connect:
  - Connected app in simulator and my phone at the same time
  - Blanked out access token and refresh token in backend; was correctly prompted to re-connect

## Demo

[YouTube](https://www.youtube.com/watch?v=pT09HXNNwtc) (unlisted)

## Types of changes
- [x] Breaking change
  - Once the backend is deployed, old versions of the app won't work with it anymore
    - The app will show an API fetch error
  - If the app is upgraded, the next API fetch will prompt the user to reconnect Patreon