### PR TITLE
Fix Android-specific issues

### DIFF
--- a/src/components/FeedButton.js
+++ b/src/components/FeedButton.js
@@ -12,6 +12,7 @@ const styles = StyleSheet.create({
     fontSize: 24,
     height: 30,
     paddingHorizontal: 20,
+    marginTop: 3,
   },
 });
 

--- a/src/components/LiturgySeriesList.js
+++ b/src/components/LiturgySeriesList.js
@@ -1,33 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ScrollView, StyleSheet, View } from 'react-native';
 
+import SeriesList from './SeriesList';
 import LiturgySeriesTile from './LiturgySeriesTile';
 import Liturgy from '../state/models/Liturgy';
 
-const styles = StyleSheet.create({
-  list: {
-    flex: 1,
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'flex-start',
-  },
-});
-
-const LiturgySeriesList = ({ liturgies, onPressLiturgy }) =>
-  (
-    <ScrollView>
-      <View style={styles.list}>
-        {liturgies.map(liturgy => (
-          <LiturgySeriesTile
-            key={liturgy.title}
-            liturgy={liturgy}
-            onPress={() => onPressLiturgy(liturgy)}
-          />
-        ))}
-      </View>
-    </ScrollView>
-  );
+const LiturgySeriesList = ({ liturgies, onPressLiturgy }) => (
+  <SeriesList>
+    {liturgies.map(liturgy => (
+      <LiturgySeriesTile
+        key={liturgy.title}
+        liturgy={liturgy}
+        onPress={() => onPressLiturgy(liturgy)}
+      />
+    ))}
+  </SeriesList>
+);
 
 LiturgySeriesList.propTypes = {
   liturgies: PropTypes.arrayOf(

--- a/src/components/MeditationSeriesList.js
+++ b/src/components/MeditationSeriesList.js
@@ -1,34 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ScrollView, StyleSheet, View } from 'react-native';
 
+import SeriesList from './SeriesList';
 import MeditationSeriesTile from './MeditationSeriesTile';
 import MeditationCategory from '../state/models/MeditationCategory';
 
-const styles = StyleSheet.create({
-  list: {
-    flex: 1,
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'flex-start',
-    paddingVertical: 7,
-  },
-});
-
-const MeditationSeriesList = ({ meditationCategories, onPressMeditationCategory }) =>
-  (
-    <ScrollView>
-      <View style={styles.list}>
-        {meditationCategories.map(meditationCategory => (
-          <MeditationSeriesTile
-            key={meditationCategory.title}
-            meditationCategory={meditationCategory}
-            onPress={() => onPressMeditationCategory(meditationCategory)}
-          />
-        ))}
-      </View>
-    </ScrollView>
-  );
+const MeditationSeriesList = ({ meditationCategories, onPressMeditationCategory }) => (
+  <SeriesList>
+    {meditationCategories.map(meditationCategory => (
+      <MeditationSeriesTile
+        key={meditationCategory.title}
+        meditationCategory={meditationCategory}
+        onPress={() => onPressMeditationCategory(meditationCategory)}
+      />
+    ))}
+  </SeriesList>
+);
 
 MeditationSeriesList.propTypes = {
   meditationCategories: PropTypes.arrayOf(

--- a/src/components/PlayerStrip.js
+++ b/src/components/PlayerStrip.js
@@ -77,7 +77,14 @@ const styles = StyleSheet.create({
     color: '#7B7B7B',
   },
   pauseButtonIconStyle: {
-    marginTop: 2,
+    // Mysteriously, the centering of this icon in its container
+    // seems to be different between iOS and Android. So, give it
+    // a nudge downward on iOS.
+    ...Platform.select({
+      ios: {
+        marginTop: 2,
+      },
+    }),
     marginLeft: 1,
     fontSize: 16,
     color: '#7B7B7B',

--- a/src/components/PlayerStrip.js
+++ b/src/components/PlayerStrip.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { StyleSheet, View, Platform, Text, TouchableWithoutFeedback } from 'react-native';
 import { connect } from 'react-redux';
 import _ from 'lodash';
+import { LinearGradient } from 'expo';
 
 import appPropTypes from '../propTypes';
 
@@ -20,6 +21,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     justifyContent: 'space-between',
     alignItems: 'center',
+    borderTopWidth: 1,
+    borderTopColor: '#eee',
     ...Platform.select({
       ios: {
         shadowColor: '#000',
@@ -105,12 +108,27 @@ function getSeriesTitle(item) {
   return _.get(item, [group, 'title']);
 }
 
+const PlayerStripContainer = ({ children, ...props }) => (
+  Platform.select({
+    ios: <View style={styles.container} {...props}>{children}</View>,
+    android: (
+      <LinearGradient
+        style={styles.container}
+        colors={['#fbf9fa', '#e5e5e5']}
+        {...props}
+      >
+        {children}
+      </LinearGradient>
+    ),
+  })
+);
+
 const PlayerStrip = ({ item, navigation: { navigate } }) => (
   item ? (
     <TouchableWithoutFeedback
       onPress={() => navigate('PlayerWithHeader')}
     >
-      <View style={styles.container}>
+      <PlayerStripContainer>
         <View style={styles.item}>
           <View style={styles.imageContainer}>
             <SquareImage
@@ -132,7 +150,7 @@ const PlayerStrip = ({ item, navigation: { navigate } }) => (
             pauseButtonIconStyle={styles.pauseButtonIconStyle}
           />
         </View>
-      </View>
+      </PlayerStripContainer>
     </TouchableWithoutFeedback>
   ) : null
 );

--- a/src/components/PodcastSeriesList.js
+++ b/src/components/PodcastSeriesList.js
@@ -1,34 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ScrollView, StyleSheet, View } from 'react-native';
 
+import SeriesList from './SeriesList';
 import PodcastSeriesTile from './PodcastSeriesTile';
 import Podcast from '../state/models/Podcast';
 
-const styles = StyleSheet.create({
-  list: {
-    flex: 1,
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'flex-start',
-    paddingVertical: 7,
-  },
-});
+const PodcastSeriesList = ({ podcasts, onPressPodcast }) => (
+  <SeriesList>
+    {podcasts.map(podcast => (
+      <PodcastSeriesTile
+        key={podcast.title}
+        podcast={podcast}
+        onPress={() => onPressPodcast(podcast)}
+      />
+    ))}
+  </SeriesList>
+);
 
-const PodcastSeriesList = ({ podcasts, onPressPodcast }) =>
-  (
-    <ScrollView>
-      <View style={styles.list}>
-        {podcasts.map(podcast => (
-          <PodcastSeriesTile
-            key={podcast.title}
-            podcast={podcast}
-            onPress={() => onPressPodcast(podcast)}
-          />
-        ))}
-      </View>
-    </ScrollView>
-  );
 PodcastSeriesList.propTypes = {
   podcasts: PropTypes.arrayOf(
     PropTypes.shape(

--- a/src/components/SeriesList.js
+++ b/src/components/SeriesList.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ScrollView, StyleSheet, View } from 'react-native';
+
+import { cardMargin } from './SeriesTile';
+
+const styles = StyleSheet.create({
+  list: {
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-start',
+    padding: cardMargin,
+  },
+  cardSpacing: {
+    margin: cardMargin,
+  },
+});
+
+const SeriesList = ({ children }) => (
+  <ScrollView>
+    <View style={styles.list}>
+      {children}
+    </View>
+  </ScrollView>
+);
+
+SeriesList.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default SeriesList;

--- a/src/components/SeriesTile.js
+++ b/src/components/SeriesTile.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, StyleSheet, Platform, TouchableWithoutFeedback } from 'react-native';
+import { View, Text, StyleSheet, Platform, TouchableWithoutFeedback, ViewPropTypes } from 'react-native';
 import { normalize } from 'react-native-elements';
 import fonts from 'react-native-elements/src/config/fonts';
 import colors from '../styles/colors';
@@ -13,18 +13,17 @@ import { screenRelativeWidth } from './utils';
 // using the width of the container, adjusted for padding, margin, and border radius
 const imageWidth = screenRelativeWidth(0.46) - 9 - 6 - 4;
 
+const cardWidthFraction = 0.46;
+const cardSpaceWidthFraction = (1.0 - (cardWidthFraction * 2)) / 3;
+
+// export so that SeriesList can use it too
+export const cardMargin = screenRelativeWidth(cardSpaceWidthFraction / 2);
+
 const styles = StyleSheet.create({
-  // Tile wrapper base
   container: {
-    /*
-        Styles to create 2 vertical columns
-        of left justified columns. There might
-        be a more efficient way of doing this
-    */
-    marginHorizontal: 6,
-    marginVertical: 6,
     padding: 9,
     width: screenRelativeWidth(0.46),
+    margin: cardMargin,
     borderRadius: 4,
     justifyContent: 'center',
     alignItems: 'center',
@@ -76,10 +75,10 @@ const styles = StyleSheet.create({
 });
 
 const SeriesTile = ({
-  onPress, imageSource, title, description,
+  onPress, imageSource, title, description, style,
 }) => (
   <TouchableWithoutFeedback onPress={onPress}>
-    <View style={styles.container}>
+    <View style={[styles.container, style]}>
       <View style={styles.imageContainer}>
         <SquareImage
           source={imageSource}
@@ -99,11 +98,13 @@ SeriesTile.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   onPress: PropTypes.func,
+  style: ViewPropTypes.style,
 };
 
 SeriesTile.defaultProps = {
   imageSource: undefined,
   onPress: () => {},
+  style: {},
 };
 
 export default SeriesTile;

--- a/src/navigation/MainNavigator.js
+++ b/src/navigation/MainNavigator.js
@@ -37,6 +37,7 @@ const HomeNavigator = createStackNavigator({
   navigationOptions: {
     tabBarIcon: HomeIcon,
   },
+  headerLayoutPreset: 'center',
 });
 
 const PodcastsNavigator = createStackNavigator({
@@ -45,7 +46,9 @@ const PodcastsNavigator = createStackNavigator({
   SinglePodcastEpisode: SinglePodcastEpisodeScreen,
   Contributor: ContributorScreen,
   SearchResults: SearchResultsScreen,
-}, {});
+}, {
+  headerLayoutPreset: 'center',
+});
 
 PodcastsNavigator.navigationOptions = {
   tabBarIcon: PodcastsIcon,
@@ -57,7 +60,9 @@ const MeditationsNavigator = createStackNavigator({
   SingleMeditation: SingleMeditationScreen,
   Contributor: ContributorScreen,
   SearchResults: SearchResultsScreen,
-}, {});
+}, {
+  headerLayoutPreset: 'center',
+});
 
 MeditationsNavigator.navigationOptions = {
   tabBarIcon: MeditationsIcon,
@@ -69,7 +74,9 @@ const LiturgiesNavigator = createStackNavigator({
   SingleLiturgyItem: SingleLiturgyItemScreen,
   Contributor: ContributorScreen,
   SearchResults: SearchResultsScreen,
-}, {});
+}, {
+  headerLayoutPreset: 'center',
+});
 
 LiturgiesNavigator.navigationOptions = {
   tabBarIcon: LiturgiesIcon,

--- a/src/screens/MeditationsCategoryScreen.js
+++ b/src/screens/MeditationsCategoryScreen.js
@@ -34,7 +34,7 @@ const MeditationsCategoryScreen = ({
   refreshMeditations,
 }) => (
   <FlatList
-    style={styles.container}
+    contentContainerStyle={styles.container}
     refreshing={refreshing}
     onRefresh={() => refreshMeditations()}
     data={meditations}

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -56,8 +56,13 @@ const styles = StyleSheet.create({
   buttonText: {
     color: 'white',
     fontWeight: '900',
-    textTransform: 'uppercase',
+
+    // textTransform doesn't work on Android until react-native 0.57.4,
+    // which will be part of Expo SDK 33.
+    // textTransform: 'uppercase',
+
     marginLeft: 40,
+    marginTop: -2.5,
     fontSize: 13,
   },
   closeIcon: {
@@ -223,7 +228,7 @@ const PatreonConnectButton = ({
   connect: connectPatreon,
   disconnect,
 }) => {
-  const title = isConnected ? 'Disconnect Patreon' : 'Connect with Patreon';
+  const title = isConnected ? 'DISCONNECT PATREON' : 'CONNECT WITH PATREON';
   const onPress = (
     isConnected
       ? () => Alert.alert(
@@ -267,7 +272,7 @@ const PatreonRefreshButton = ({
 }) => (
   isConnected ?
     <PatreonButton
-      title={loading ? 'Refreshing...' : 'Refresh Patron Status'}
+      title={loading ? 'REFRESHING...' : 'REFRESH PATREON STATUS'}
       disabled={loading}
       opacity={loading ? 0.75 : 1.0}
       onPress={() => {

--- a/src/screens/PlayerScreen/Controls.js
+++ b/src/screens/PlayerScreen/Controls.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
+  Platform,
   StyleSheet,
   TouchableWithoutFeedback,
   Text,
@@ -41,7 +42,15 @@ const styles = StyleSheet.create({
   pauseIcon: {
     fontSize: 48,
     color: '#7B7B7B',
-    marginTop: 4,
+
+    // Mysteriously, the centering of this icon in its container
+    // seems to be different between iOS and Android. So, give it
+    // a nudge downward on iOS.
+    ...Platform.select({
+      ios: {
+        marginTop: 4,
+      },
+    }),
   },
   jumpIconContainer: {
     justifyContent: 'center',

--- a/src/screens/PlayerScreen/index.js
+++ b/src/screens/PlayerScreen/index.js
@@ -37,15 +37,14 @@ const styles = StyleSheet.create({
         elevation: 3,
       },
     }),
-    height: screenRelativeHeight(0.5),
+    height: screenRelativeWidth(0.8),
     borderRadius: 4,
     flexDirection: 'column',
     position: 'absolute',
     top: screenRelativeHeight(0.05),
+    maxHeight: screenRelativeHeight(0.4),
   },
-  coverArtImage: {
-    maxHeight: screenRelativeWidth(1) - 90,
-  },
+  coverArtImage: {},
   mediaContainer: {
     height: 194,
     width: '95%',

--- a/src/screens/PodcastScreen.js
+++ b/src/screens/PodcastScreen.js
@@ -30,7 +30,7 @@ const PodcastScreen = ({
   refreshPodcastEpisodes,
 }) => (
   <FlatList
-    style={styles.container}
+    contentContainerStyle={styles.container}
     refreshing={refreshing}
     onRefresh={() => refreshPodcastEpisodes()}
     data={episodes}


### PR DESCRIPTION
## Description
- Lots of minor Android-related fixups
- Bonus transparency bug fix since you're such a good customer

## Motivation and Context
Closes #166.

## How Has This Been Tested?
Each problem found in #166 was retested on both iOS and Android.

## Screenshots 
| Issue | Before | After |
|--|--|--|
| Pause icon | <img width="480" alt="Screen Shot 2019-06-02 at 9 37 28 PM" src="https://user-images.githubusercontent.com/91550/58770747-c3de2580-857e-11e9-93be-84adf83b3b8e.png"> | <img width="480" alt="Screen Shot 2019-06-02 at 9 38 12 PM" src="https://user-images.githubusercontent.com/91550/58770756-cb053380-857e-11e9-9036-73a8c2e5b5d3.png"> |
| Player screen | <img width="480" alt="Screen Shot 2019-06-02 at 9 40 42 PM" src="https://user-images.githubusercontent.com/91550/58770837-30592480-857f-11e9-875c-d7238569b088.png"> | <img width="480" alt="Screen Shot 2019-06-02 at 9 41 16 PM" src="https://user-images.githubusercontent.com/91550/58770846-37803280-857f-11e9-8709-e3484193208b.png"> |
| Mini player | <img width="500" alt="Screen Shot 2019-06-02 at 9 43 57 PM" src="https://user-images.githubusercontent.com/91550/58770932-a1004100-857f-11e9-98a3-0961e8428bea.png"> | <img width="500" alt="Screen Shot 2019-06-02 at 9 44 28 PM" src="https://user-images.githubusercontent.com/91550/58770935-a78eb880-857f-11e9-9d58-1117fe51cf77.png"> |
| Collection list, RSS icon | <img width="500" alt="Screen Shot 2019-06-02 at 9 46 50 PM" src="https://user-images.githubusercontent.com/91550/58771001-f63c5280-857f-11e9-9d53-1f92c5db806c.png"> | <img width="500" alt="Screen Shot 2019-06-02 at 9 46 20 PM" src="https://user-images.githubusercontent.com/91550/58771014-ff2d2400-857f-11e9-8553-cde7c426dc11.png"> |
| Patreon buttons | <img width="360" alt="Screen Shot 2019-06-02 at 9 49 01 PM" src="https://user-images.githubusercontent.com/91550/58771073-54693580-8580-11e9-841e-f2987018bc84.png"> | <img width="360" alt="Screen Shot 2019-06-02 at 9 49 31 PM" src="https://user-images.githubusercontent.com/91550/58771080-592de980-8580-11e9-999b-017e9dd50efa.png"> |
| "Liturgies" text overlap | <img width="486" alt="Screen Shot 2019-06-02 at 9 51 02 PM" src="https://user-images.githubusercontent.com/91550/58771125-8b3f4b80-8580-11e9-9f45-c6e0e72e37e3.png"> | <img width="486" alt="Screen Shot 2019-06-02 at 9 50 45 PM" src="https://user-images.githubusercontent.com/91550/58771134-909c9600-8580-11e9-86eb-4c11738a5a5d.png"> |
| Transparency | <img width="493" alt="Screen Shot 2019-06-02 at 9 52 34 PM" src="https://user-images.githubusercontent.com/91550/58771189-c9d50600-8580-11e9-8cbb-134f3249b91d.png"> | <img width="493" alt="Screen Shot 2019-06-02 at 9 52 49 PM" src="https://user-images.githubusercontent.com/91550/58771193-cfcae700-8580-11e9-8bfc-6a4b860fe93a.png"> |