### PR TITLE
Assorted accessibility improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,4 @@ Pods
 /ios/the-liturgists/Supporting/EXBuildConstants.plist.bak
 /ios/the-liturgists/Supporting/EXBuildConstants.json
 /ios/the-liturgists/Supporting/EXBuildConstants.plist
+/android/app/src/main/java/host/exp/exponent/generated/DetachBuildConstants.java

--- a/android/app/src/main/java/host/exp/exponent/generated/DetachBuildConstants.java
+++ b/android/app/src/main/java/host/exp/exponent/generated/DetachBuildConstants.java
@@ -1,8 +1,0 @@
-package host.exp.exponent.generated;
-
-// This file is auto-generated. Please don't rename!
-public class DetachBuildConstants {
-
-  public static final String DEVELOPMENT_URL = "theliturgists.app://192.168.7.67:19000";
-
-}

--- a/src/Root.js
+++ b/src/Root.js
@@ -53,7 +53,6 @@ function getItem(notification) {
 }
 
 function navigateFromNotification(notification) {
-  console.log('Opened with notification: ', notification);
   const item = getItem(notification);
   if (item) {
     const action = navActions.openItem(item);

--- a/src/components/FeedButton.js
+++ b/src/components/FeedButton.js
@@ -25,9 +25,13 @@ function copyFeed(url) {
   );
 }
 
-const FeedButton = ({ url }) => (
+const FeedButton = ({ collection, url }) => (
   url ? (
-    <TouchableOpacity onPress={() => copyFeed(url)}>
+    <TouchableOpacity
+      onPress={() => copyFeed(url)}
+      accessible
+      accessibilityLabel={`Copy feed URL for ${collection.title}`}
+    >
       <Icon
         name="rss"
         style={styles.icon}
@@ -40,6 +44,7 @@ FeedButton.propTypes = {
   collection: PropTypes.shape({
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
     feedUrl: PropTypes.string,
   }).isRequired,
   url: PropTypes.string,

--- a/src/components/PersonCard.js
+++ b/src/components/PersonCard.js
@@ -51,7 +51,12 @@ const styles = StyleSheet.create({
 });
 
 const PersonCard = ({ person, onPress, style }) => (
-  <TouchableWithoutFeedback onPress={onPress}>
+  <TouchableWithoutFeedback
+    onPress={onPress}
+    accessible
+    accessibilityLabel={person.name}
+    accessibilityHint="Open this person's contributor screen"
+  >
     <View style={[styles.card, style]}>
       <CircleImage
         source={getImageSource(person)}

--- a/src/components/PlayableItemHeader.js
+++ b/src/components/PlayableItemHeader.js
@@ -96,7 +96,13 @@ const DownloadButton = ({ isDownloaded, downloadProgress, onPress }) => {
     />
   ) : null;
   return (
-    <TouchableWithoutFeedback onPress={onPress} disabled={disabled}>
+    <TouchableWithoutFeedback
+      onPress={onPress}
+      disabled={disabled}
+      accessible
+      accessibilityLabel={isDownloaded ? 'Delete download' : 'Download'}
+      accessibilityRole="button"
+    >
       <View style={styles.downloadButton}>
         {icon}
         {progress}

--- a/src/components/PlayerStrip.js
+++ b/src/components/PlayerStrip.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { StyleSheet, View, Platform, Text, TouchableWithoutFeedback } from 'react-native';
 import { connect } from 'react-redux';
-import _ from 'lodash';
 import { LinearGradient } from 'expo-linear-gradient';
 
 import appPropTypes from '../propTypes';
@@ -10,7 +9,7 @@ import SquareImage from '../components/SquareImage';
 import Controls from '../screens/PlayerScreen/Controls';
 import * as actions from '../state/ducks/playback/actions';
 import * as selectors from '../state/ducks/playback/selectors';
-import { getImageSource } from '../state/ducks/orm/utils';
+import { getImageSource, getGroupField, getSeriesTitle } from '../state/ducks/orm/utils';
 
 const styles = StyleSheet.create({
   container: {
@@ -103,11 +102,6 @@ const styles = StyleSheet.create({
   },
 });
 
-function getSeriesTitle(item) {
-  const group = ['category', 'podcast', 'liturgy'].find(g => _.has(item, g));
-  return _.get(item, [group, 'title']);
-}
-
 const PlayerStripContainer = ({ children, ...props }) => (
   Platform.select({
     ios: <View style={styles.container} {...props}>{children}</View>,
@@ -123,9 +117,21 @@ const PlayerStripContainer = ({ children, ...props }) => (
   })
 );
 
+function getAccessibilityLabel(item) {
+  const group = getGroupField(item);
+  if (!group) {
+    return item.title;
+  }
+
+  const seriesTitle = getSeriesTitle(item);
+  return `${item.title}, from the ${group}: ${seriesTitle}`;
+}
+
 const PlayerStrip = ({ item, navigation: { navigate } }) => (
   item ? (
     <TouchableWithoutFeedback
+      accessibilityLabel={`Now Playing: ${getAccessibilityLabel(item)}`}
+      accessibilityHint="Tap to open Now Playing screen"
       onPress={() => navigate('PlayerWithHeader')}
     >
       <PlayerStripContainer>

--- a/src/components/SocialLinksSection.js
+++ b/src/components/SocialLinksSection.js
@@ -55,11 +55,13 @@ const links = [
     imageSource: mastodonIcon,
     url: 'https://social.theliturgists.com',
     style: styles.mastodonIconContainer,
+    label: 'Talk on Mastodon',
   },
   {
     imageSource: slackIcon,
     url: 'http://bit.ly/JoinLiturgistsSlack',
     style: styles.slackIconContainer,
+    label: 'Discuss in Slack',
   },
 ];
 
@@ -71,9 +73,14 @@ const SocialLinksSection = () => (
       </View>
     </View>
     <View style={styles.linkContainer}>
-      {links.map(({ imageSource, url, style }) => (
+      {links.map(({
+        imageSource, url, style, label,
+      }) => (
         <TouchableWithoutFeedback
           key={url}
+          accessible
+          accessibilityLabel={label}
+          accessibilityHint="Opens a web browser"
           onPress={() => Linking.openURL(url)}
         >
           <View style={[styles.linkImageContainer, style]}>

--- a/src/components/TextPill.js
+++ b/src/components/TextPill.js
@@ -24,10 +24,12 @@ const styles = StyleSheet.create({
   },
 });
 
-const TextPill = ({ style, children, onPress }) => (
+const TextPill = ({
+  style, textStyle, children, onPress, ...props
+}) => (
   <TouchableWithoutFeedback onPress={onPress}>
     <View style={[styles.container, style]}>
-      <Text style={styles.text}>
+      <Text style={[styles.text, textStyle]} {...props}>
         {children.toUpperCase()}
       </Text>
     </View>
@@ -40,11 +42,15 @@ TextPill.propTypes = {
   // eslint-disable-next-line react/no-typos
   style: ViewPropTypes.style,
 
+  // eslint-disable-next-line react/no-typos
+  textStyle: Text.propTypes.style,
+
   onPress: PropTypes.func,
 };
 
 TextPill.defaultProps = {
   style: {},
+  textStyle: {},
   onPress: () => {},
 };
 

--- a/src/navigation/DrawerContent.js
+++ b/src/navigation/DrawerContent.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Image,
-  NativeModules,
-  StyleSheet,
-} from 'react-native';
+import { Image, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import { withNavigation } from 'react-navigation';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -48,8 +44,8 @@ const DrawerContent = ({
     />
     <DrawerItem
       drawer={drawer}
-      title="Open dev menu"
-      onPress={() => NativeModules.DevMenu.show()}
+      title="Close menu"
+      onPress={() => drawer.closeDrawer()}
     />
   </LinearGradient>
 );

--- a/src/navigation/MenuButton.js
+++ b/src/navigation/MenuButton.js
@@ -17,6 +17,8 @@ const styles = StyleSheet.create({
 const MenuButton = ({ drawer }) => (
   <Icon
     name="menu"
+    accessibilityLabel="Menu button"
+    accessibilityHint="Opens the sidebar menu"
     style={styles.menuIcon}
     onPress={() => drawer && drawer.openDrawer()}
   />

--- a/src/screens/ContributorScreen/Socials.js
+++ b/src/screens/ContributorScreen/Socials.js
@@ -20,7 +20,12 @@ const styles = StyleSheet.create({
 const getIconName = service => (service === 'website' ? 'globe' : service);
 
 const SocialButton = ({ contributor, service }) => (
-  <TouchableWithoutFeedback onPress={() => Linking.openURL(contributor[service])}>
+  <TouchableWithoutFeedback
+    accessible
+    accessibilityLabel={service}
+    accessibilityHint="Opens a web browser"
+    onPress={() => Linking.openURL(contributor[service])}
+  >
     <Entypo name={getIconName(service)} style={styles.socialButton} />
   </TouchableWithoutFeedback>
 );

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -19,7 +19,7 @@ import appPropTypes from '../propTypes';
 import { getCommonNavigationOptions } from '../navigation/common';
 import * as navActions from '../navigation/actions';
 import { recentMediaItemsSelector } from '../state/ducks/orm/selectors';
-import { getImageSource } from '../state/ducks/orm/utils';
+import { getImageSource, getSeriesTitle } from '../state/ducks/orm/utils';
 import { fetchData } from '../state/ducks/orm/actions';
 import * as playbackSelectors from '../state/ducks/playback/selectors';
 import { screenRelativeWidth, screenRelativeHeight, formatFooter } from '../components/utils';
@@ -42,10 +42,23 @@ const styles = StyleSheet.create({
   mediaTypeContainer: {
     flexDirection: 'row',
     marginBottom: screenRelativeHeight(0.01),
+    width: screenRelativeWidth(0.85),
   },
   title: {
     fontSize: 24,
     fontWeight: '600',
+  },
+  itemTypePill: {
+    zIndex: 3,
+  },
+  seriesTitlePill: {
+    marginLeft: -10,
+    backgroundColor: '#ccc',
+  },
+  seriesTitle: {
+    flex: 1,
+    marginLeft: 9,
+    color: '#000',
   },
   details: {
     color: '#9B9B9B',
@@ -85,6 +98,7 @@ class HomeScreen extends React.Component {
           items.map(item => (
             <TouchableWithoutFeedback
               key={item.id}
+              accessible
               onPress={() => onItemPress(item)}
             >
               <View style={styles.itemContainer}>
@@ -93,8 +107,15 @@ class HomeScreen extends React.Component {
                   source={getImageSource(item, true)}
                 />
                 <View style={styles.mediaTypeContainer}>
-                  <TextPill>
+                  <TextPill style={styles.itemTypePill}>
                     {item.type.replace('Episode', '')}
+                  </TextPill>
+                  <TextPill
+                    style={styles.seriesTitlePill}
+                    textStyle={styles.seriesTitle}
+                    numberOfLines={1}
+                  >
+                    {getSeriesTitle(item)}
                   </TextPill>
                 </View>
                 <Text style={styles.title} numberOfLines={1}>

--- a/src/screens/MeditationsCategoryScreen.js
+++ b/src/screens/MeditationsCategoryScreen.js
@@ -93,7 +93,7 @@ function mapDispatchToProps(dispatch) {
 MeditationsCategoryScreen.navigationOptions = ({ screenProps, navigation }) => ({
   ...getCommonNavigationOptions(screenProps.drawer),
   headerLeft: <BackButton />,
-  headerRight: <FeedButton collection={getCategory(navigation)} onPress={() => {}} />,
+  headerRight: <FeedButton collection={getCategory(navigation)} />,
   title: navigation.state.params.category.title,
 });
 

--- a/src/screens/PlayerScreen/AudioTimeline.js
+++ b/src/screens/PlayerScreen/AudioTimeline.js
@@ -87,37 +87,89 @@ function renderStatus(status) {
   return bufferStatus;
 }
 
+function formatDurationForSpeech(duration) {
+  if (!duration) {
+    return 'none';
+  }
+
+  const components = [`${duration.seconds()} seconds`];
+  if (duration.minutes() > 0) {
+    components.unshift(`${duration.minutes()} minutes`);
+  }
+  if (duration.hours() > 0) {
+    components.unshift(`${duration.hours()} hours`);
+  }
+  return components.join(', ');
+}
+
 const AudioTimeline = ({
   style,
   duration,
   elapsed,
   status,
   seek,
+  jump,
   setPendingSeek,
-}) => (
-  <View style={[styles.container, style]}>
-    <View style={styles.timesContainer}>
-      <Text style={[styles.time, styles.elapsedTime]}>
-        {formatDuration(elapsed)}
-      </Text>
-      <Text style={styles.status}>{renderStatus(status)}</Text>
-      <Text style={styles.time}>
-        {formatRemainingTime(duration, elapsed)}
-      </Text>
+}) => {
+  const largeSkipMinutes = 5;
+
+  // TODO: make this accessible after upgrading to React Native >= 0.60
+  // eslint-disable-next-line
+  const onAccessibilityAction = (event) => {
+    switch (event.nativeEvent.actionName) {
+      case 'increment':
+        jump(largeSkipMinutes * 60);
+        break;
+      case 'decrement':
+        jump(-largeSkipMinutes * 60);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <View style={[styles.container, style]}>
+      <View style={styles.timesContainer}>
+        <Text
+          style={[styles.time, styles.elapsedTime]}
+          accessibilityLabel={`Elapsed: ${formatDurationForSpeech(elapsed)}`}
+        >
+          {formatDuration(elapsed)}
+        </Text>
+        <Text style={styles.status}>{renderStatus(status)}</Text>
+        <Text
+          style={styles.time}
+          accessibilityLabel={
+            `Remaining: ${formatDurationForSpeech(moment.duration(duration).subtract(elapsed))}`
+          }
+        >
+          {formatRemainingTime(duration, elapsed)}
+        </Text>
+      </View>
+      <Slider
+        // accessible
+        // accessibilityLabel="Playback progress"
+        // accessibilityHint={`Activate to seek ${largeSkipMinutes} minutes at a time`}
+        // accessiblityRole="adjustable"
+        // accessibilityActions={[
+        //   { name: 'increment', label: `Skip forward ${largeSkipMinutes} minutes` },
+        //   { name: 'decrement', label: `Skip back ${largeSkipMinutes} minutes` },
+        // ]}
+        // onAccessibilityAction={onAccessibilityAction}
+        style={styles.slider}
+        thumbStyle={styles.sliderThumb}
+        minimumValue={0}
+        maximumValue={duration.asMilliseconds()}
+        value={elapsed.asMilliseconds()}
+        minimumTrackTintColor="#F95A57"
+        onSlidingStart={value => setPendingSeek(moment.duration(value))}
+        onValueChange={value => setPendingSeek(moment.duration(value))}
+        onSlidingComplete={value => seek(moment.duration(value))}
+      />
     </View>
-    <Slider
-      style={styles.slider}
-      thumbStyle={styles.sliderThumb}
-      minimumValue={0}
-      maximumValue={duration.asMilliseconds()}
-      value={elapsed.asMilliseconds()}
-      minimumTrackTintColor="#F95A57"
-      onSlidingStart={value => setPendingSeek(moment.duration(value))}
-      onValueChange={value => setPendingSeek(moment.duration(value))}
-      onSlidingComplete={value => seek(moment.duration(value))}
-    />
-  </View>
-);
+  );
+};
 
 AudioTimeline.propTypes = {
   style: ViewPropTypes.style,
@@ -125,6 +177,7 @@ AudioTimeline.propTypes = {
   duration: momentPropTypes.momentDurationObj,
   status: PropTypes.shape({}),
   seek: PropTypes.func.isRequired,
+  jump: PropTypes.func.isRequired,
   setPendingSeek: PropTypes.func.isRequired,
 };
 

--- a/src/screens/PlayerScreen/Controls.js
+++ b/src/screens/PlayerScreen/Controls.js
@@ -30,8 +30,8 @@ const styles = StyleSheet.create({
     borderRadius: 40,
     borderColor: '#7B7B7B',
     borderWidth: 4,
-    marginLeft: 30,
-    marginRight: 30,
+    marginLeft: 20,
+    marginRight: 20,
   },
   playIcon: {
     paddingTop: 4,
@@ -53,6 +53,8 @@ const styles = StyleSheet.create({
     }),
   },
   jumpIconContainer: {
+    width: 64,
+    height: 64,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -63,7 +65,7 @@ const styles = StyleSheet.create({
   jumpIconText: {
     position: 'absolute',
     fontSize: 10,
-    bottom: 13,
+    bottom: 23,
     backgroundColor: '#fff',
     color: '#7B7B7B',
   },
@@ -76,8 +78,9 @@ export const PlaybackButton = ({
   playButtonIconStyle,
   pauseButtonIconStyle,
   disabled,
+  ...props
 }) => (
-  <TouchableWithoutFeedback onPress={onPress} disabled={disabled}>
+  <TouchableWithoutFeedback onPress={onPress} disabled={disabled} {...props}>
     <View style={[styles.playbackButton, style]}>
       {
         isPaused
@@ -137,10 +140,12 @@ let JumpButton = ({
   jump,
   iconStyle,
   disabled,
+  ...props
 }) => (
   <TouchableWithoutFeedback
     onPress={() => { jump(jumpSeconds); }}
     disabled={disabled}
+    {...props}
   >
     <View>
       <JumpIcon style={iconStyle} jumpSeconds={jumpSeconds} />
@@ -184,6 +189,7 @@ const Controls = ({
       iconStyle={jumpButtonIconStyle}
       jumpSeconds={-jumpSeconds}
       disabled={disabled}
+      accessibilityLabel={`Skip back ${jumpSeconds} seconds`}
     />
     <PlaybackButton
       style={playbackButtonStyle}
@@ -192,12 +198,14 @@ const Controls = ({
       isPaused={isPaused}
       onPress={() => (isPaused ? play(item) : pause(item))}
       disabled={disabled}
+      accessibilityLabel={isPaused ? 'Play' : 'Pause'}
     />
     <JumpButton
       style={jumpButtonStyle}
       iconStyle={jumpButtonIconStyle}
       jumpSeconds={jumpSeconds}
       disabled={disabled}
+      accessibilityLabel={`Skip forward ${jumpSeconds} seconds`}
     />
   </View>
 );

--- a/src/screens/PlayerScreen/index.js
+++ b/src/screens/PlayerScreen/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import _ from 'lodash';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 
@@ -10,7 +9,7 @@ import { screenRelativeWidth, screenRelativeHeight } from '../../components/util
 import appPropTypes from '../../propTypes';
 import * as actions from '../../state/ducks/playback/actions';
 import * as selectors from '../../state/ducks/playback/selectors';
-import { getImageSource } from '../../state/ducks/orm/utils';
+import { getImageSource, getSeriesTitle } from '../../state/ducks/orm/utils';
 import appStyles from '../../styles';
 
 import AudioTimeline from './AudioTimeline';
@@ -68,11 +67,6 @@ const styles = StyleSheet.create({
     marginTop: 30,
   },
 });
-
-function getSeriesTitle(item) {
-  const group = ['category', 'podcast', 'liturgy'].find(g => _.has(item, g));
-  return _.get(item, [group, 'title']);
-}
 
 class PlayerScreen extends React.Component {
   componentDidUpdate(prevProps) {

--- a/src/screens/SingleMediaItemScreen.js
+++ b/src/screens/SingleMediaItemScreen.js
@@ -11,7 +11,7 @@ import PlayableItemHeader from '../components/PlayableItemHeader';
 import ItemDescription from '../components/ItemDescription';
 import PersonList from '../components/PersonList';
 import SocialLinksSection from '../components/SocialLinksSection';
-import TagList from '../components/TagList';
+// import TagList from '../components/TagList';
 
 import * as playbackActions from '../state/ducks/playback/actions';
 import * as playbackSelectors from '../state/ducks/playback/selectors';
@@ -85,7 +85,8 @@ const SingleMediaItemScreen = ({
         />
       </View>
       <View style={styles.subContainer}>
-        <TagList tags={item.tags} />
+        {/* Disable tags until we can make them tappable */}
+        {/* <TagList tags={item.tags} /> */}
         <SocialLinksSection />
       </View>
     </ScrollView>

--- a/src/state/ducks/orm/utils.js
+++ b/src/state/ducks/orm/utils.js
@@ -19,6 +19,14 @@ export function getCollectionName(type) {
   return uncapitalize(pluralize(type));
 }
 
+export function getGroupField(item) {
+  return ['category', 'podcast', 'liturgy'].find(g => _.has(item, g));
+}
+
+export function getSeriesTitle(item) {
+  const group = getGroupField(item);
+  return _.get(item, [group, 'title']);
+}
 
 // contentful-specific utility functions follow
 


### PR DESCRIPTION
## Description
- Added labels for several controls:
  - Download / delete-download button
  - "Copy Feed URL" button
  - Person cards
  - Miniplayer bar
  - Social buttons on media items
  - Sidebar menu button
  - Social links on contributor screen
  - Player screen:
    - Play/pause, jump back/forward buttons
    - Elapsed/remaining times (humanized readout)
- Added podcast/meditation-category/liturgy name to home screen cards
- Added "Close menu" button to sidebar menu
  - Otherwise screenreader users would get stuck in the sidebar

Misc:
- Disabled tags list until we can make them tappable

## Motivation and Context
Closes #168.

## How Has This Been Tested?
Poked around the app, attempting to cover every screen. Inspected each element with the Accessibility Inspector and/or Voiceover. Did some of the same on Android with TalkBack.