### PR TITLE
Filter all media items by tag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
     'no-underscore-dangle': 'off',
     'function-paren-newline': ['error', 'consistent'],
+    'prefer-destructuring': 'off',
   },
   // https://github.com/benmosher/eslint-plugin-import/issues/279#issuecomment-215052176
   settings: {

--- a/src/components/PlayableListCard.js
+++ b/src/components/PlayableListCard.js
@@ -83,8 +83,8 @@ const styles = StyleSheet.create({
   description: {
     fontSize: 12,
     color: '#797979',
-    minHeight: '45%',
-    marginVertical: '2%',
+    minHeight: 40,
+    marginVertical: 5,
     flexWrap: 'wrap',
     flexDirection: 'column',
   },
@@ -99,9 +99,10 @@ const styles = StyleSheet.create({
   searchHeader: {
     flexDirection: 'row',
     alignItems: 'center',
+    marginBottom: 3,
   },
   mediaType: {
-    marginRight: '3%',
+    marginRight: 5,
   },
 });
 
@@ -163,7 +164,7 @@ const PlayableListCard = ({
     <View style={styles.metadataContainer}>
       {isSearchResult ? (
         <View style={styles.searchHeader}>
-          <TextPill style={styles.mediaType}>{pluralize.singular(item.type)}</TextPill>
+          <TextPill style={styles.mediaType}>{pluralize.singular(item.type.replace('Episode', ''))}</TextPill>
           <Text style={styles.times}>
             {formatFooter({
               duration: item.duration,

--- a/src/screens/ContributorScreen/Contributions.js
+++ b/src/screens/ContributorScreen/Contributions.js
@@ -98,7 +98,7 @@ const Contributions = ({
         onPress={() => viewAll()}
       >
         <Text style={styles.buttonText}>
-          {`View All ${getTitle({ type, contributor })}`}
+          {`View All ${getTitle({ type, filterField: 'contributor', filterValue: contributor })}`}
         </Text>
       </Button>
     </View>
@@ -140,7 +140,7 @@ function mapDispatchToProps(dispatch, { contributor, type, navigation }) {
   return {
     viewAll: () => navigation.navigate({
       routeName: 'SearchResults',
-      params: { contributor, type },
+      params: { filterField: 'contributor', filterValue: contributor, type },
     }),
   };
 }

--- a/src/screens/SearchResultsScreen.js
+++ b/src/screens/SearchResultsScreen.js
@@ -34,6 +34,11 @@ const listCardTypes = {
   liturgyItem: LiturgyItemListCard,
 };
 
+function getParams(navigation) {
+  const { state: { params } } = navigation;
+  return params;
+}
+
 /**
  * List of items matching a search - e.g. matches contributor.
  */
@@ -41,21 +46,32 @@ const SearchResultsScreen = ({
   items,
   refreshing,
   refresh,
-}) => (
-  <FlatList
-    style={styles.container}
-    refreshing={refreshing}
-    onRefresh={() => refresh()}
-    data={items}
-    keyExtractor={item => item.id}
-    renderItem={
-      ({ item }) => {
-        const ItemListCard = listCardTypes[item.type];
-        return <ItemListCard key={item.id} style={styles.card} item={item} />;
+  navigation,
+}) => {
+  const { type } = getParams(navigation);
+  return (
+    <FlatList
+      style={styles.container}
+      refreshing={refreshing}
+      onRefresh={() => refresh()}
+      data={items}
+      keyExtractor={item => item.id}
+      renderItem={
+        ({ item }) => {
+          const ItemListCard = listCardTypes[item.type];
+          return (
+            <ItemListCard
+              key={item.id}
+              style={styles.card}
+              item={item}
+              isSearchResult={!type}
+            />
+          );
+        }
       }
-    }
-  />
-);
+    />
+  );
+};
 
 SearchResultsScreen.propTypes = {
   items: PropTypes.arrayOf(
@@ -63,12 +79,8 @@ SearchResultsScreen.propTypes = {
   ).isRequired,
   refreshing: PropTypes.bool.isRequired,
   refresh: PropTypes.func.isRequired,
+  navigation: appPropTypes.navigation.isRequired,
 };
-
-function getParams(navigation) {
-  const { state: { params } } = navigation;
-  return params;
-}
 
 function makeMapStateToProps(factoryState, { navigation }) {
   const { type, filterField, filterValue } = getParams(navigation);

--- a/src/screens/SearchResultsScreen.js
+++ b/src/screens/SearchResultsScreen.js
@@ -6,7 +6,12 @@ import pluralize from 'pluralize';
 
 import { getCommonNavigationOptions } from '../navigation/common';
 import BackButton from '../navigation/BackButton';
-import { filteredCollectionSelector, apiLoadingSelector } from '../state/ducks/orm/selectors';
+import {
+  filteredAllMediaSelector,
+  filteredCollectionSelector,
+  apiLoadingSelector,
+} from '../state/ducks/orm/selectors';
+import { capitalize } from '../state/ducks/orm/utils';
 import { fetchData } from '../state/ducks/orm';
 import appPropTypes from '../propTypes';
 import PodcastEpisodeListCard from '../components/PodcastEpisodeListCard';
@@ -66,18 +71,20 @@ function getParams(navigation) {
 }
 
 function makeMapStateToProps(factoryState, { navigation }) {
-  const { type, contributor } = getParams(navigation);
-  const selector = filteredCollectionSelector(
-    factoryState,
-    type,
-    item => item.contributors.filter(contributor).count() > 0,
+  const { type, filterField, filterValue } = getParams(navigation);
+  const filterFunc = item => item[`${filterField}s`].filter(filterValue).count() > 0;
+  const selector = (
+    type
+      ? filteredCollectionSelector(factoryState, type, filterFunc)
+      : filteredAllMediaSelector(factoryState, filterFunc)
   );
 
   return function mapStateToProps(state) {
+    const resources = type ? [type] : ['podcastEpisode', 'meditation', 'liturgyItem'];
     return {
       items: selector(state),
       refreshing: (
-        apiLoadingSelector(state, pluralize(type))
+        resources.some(resource => apiLoadingSelector(state, pluralize(resource)))
       ),
     };
   };
@@ -85,29 +92,51 @@ function makeMapStateToProps(factoryState, { navigation }) {
 
 function mapDispatchToProps(dispatch, { navigation }) {
   const { type } = getParams(navigation);
+  const resources = type ? [type] : ['podcastEpisode', 'meditation', 'liturgyItem'];
   return {
     refresh: () => {
-      dispatch(
-        fetchData({
-          resource: type,
-        }),
+      resources.forEach(
+        resource => dispatch(fetchData({ resource })),
       );
     },
   };
 }
 
-export function getTitle({ type, contributor }) {
+export function getTitle({ type, filterField, filterValue }) {
   // for now, search results are limited to links from contributor screens,
   // so we're keeping the title simple and informative based on that.
-  const title = {
-    podcastEpisode: 'Podcasts',
-    meditation: 'Meditations',
-    liturgyItem: 'Liturgies',
-  }[type];
-  const firstName = contributor.name.split(' ')[0];
-  return `${title} with ${firstName}`;
+  let name;
+  switch (filterField) {
+    case 'contributor':
+      name = filterValue.name.split(' ')[0];
+      break;
+    case 'tag':
+      name = filterValue.name;
+      break;
+    default:
+      throw new Error(`Unknown filterField ${filterField}`);
+  }
+
+  if (type) {
+    const title = {
+      podcastEpisode: 'Podcasts',
+      meditation: 'Meditations',
+      liturgyItem: 'Liturgies',
+    }[type];
+
+    return `${title} with ${name}`;
+  }
+
+  return `${capitalize(filterField)}: ${filterValue.name}`;
 }
 
+/*
+ * Navigation props:
+ *   type: 'podcastEpisode', 'meditation', 'liturgyItem', or null
+ *     limits results to that type, if not null
+ *   filterField: 'contributor' or 'tag'
+ *   filterValue: value of the field to filter by
+ */
 SearchResultsScreen.navigationOptions = ({ screenProps, navigation }) => ({
   ...getCommonNavigationOptions(screenProps.drawer),
   headerLeft: <BackButton />,

--- a/src/screens/SingleMediaItemScreen.js
+++ b/src/screens/SingleMediaItemScreen.js
@@ -11,7 +11,7 @@ import PlayableItemHeader from '../components/PlayableItemHeader';
 import ItemDescription from '../components/ItemDescription';
 import PersonList from '../components/PersonList';
 import SocialLinksSection from '../components/SocialLinksSection';
-// import TagList from '../components/TagList';
+import TagList from '../components/TagList';
 
 import * as playbackActions from '../state/ducks/playback/actions';
 import * as playbackSelectors from '../state/ducks/playback/selectors';
@@ -85,8 +85,15 @@ const SingleMediaItemScreen = ({
         />
       </View>
       <View style={styles.subContainer}>
-        {/* Disable tags until we can make them tappable */}
-        {/* <TagList tags={item.tags} /> */}
+        <TagList
+          tags={item.tags}
+          onTagPress={(tag) => {
+            navigation.navigate({
+              routeName: 'SearchResults',
+              params: { filterField: 'tag', filterValue: tag },
+            });
+          }}
+        />
         <SocialLinksSection />
       </View>
     </ScrollView>

--- a/src/state/ducks/orm/selectors.js
+++ b/src/state/ducks/orm/selectors.js
@@ -241,6 +241,20 @@ export function filteredCollectionSelector(state, type, filterFunc = () => true)
   return selector;
 }
 
+export function filteredAllMediaSelector(state, filterFunc = () => true) {
+  const selectors = ['podcastEpisode', 'meditation', 'liturgyItem'].map(
+    type => filteredCollectionSelector(state, type, filterFunc),
+  );
+  return (outerState) => {
+    const items = _.flatMap(
+      selectors, selector => selector(outerState),
+    );
+    return items.sort((a, b) => (
+      moment(b.publishedAt) - moment(a.publishedAt)
+    ));
+  };
+}
+
 export function instanceSelector(state, type, id) {
   return instanceSelectors[type](state, id);
 }


### PR DESCRIPTION
## Description
Tapping on a tag now takes you to a list of all items with that tag.

## Motivation and Context
There are a lot of different items in the app that match certain categories. This allows interested users to explore those categories more easily.

## How Has This Been Tested?
- Tapped on a few tags in a few items
- Verified that filtering by contributor still works

## Demo
https://youtu.be/R2V1-a7QQss