### PR TITLE
Add Discourse counts and link to playable item headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-native-render-html": "^4.1.1",
     "react-native-screens": "1.0.0-alpha.22",
     "react-native-slider": "^0.11.0",
+    "react-native-text-ticker": "^0.18.0",
     "react-native-unimodules": "^0.4.0",
     "react-navigation": "^3.11.0",
     "react-navigation-tabs": "^1.0.1",

--- a/src/components/InteractionsCounter/Counter.js
+++ b/src/components/InteractionsCounter/Counter.js
@@ -13,6 +13,10 @@ function getLabelNode(label) {
   return label;
 }
 
+function formatCount(count) {
+  return count === null ? '-' : numeral(count).format('0,0');
+}
+
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
@@ -27,7 +31,7 @@ const Counter = ({ label, count, style }) => {
   return (
     <View style={[styles.container, style]}>
       {labelNode}
-      <Text style={{ paddingLeft: 4 }}>{numeral(count).format('0,0')}</Text>
+      <Text style={{ paddingLeft: 4 }}>{formatCount(count)}</Text>
     </View>
   );
 };
@@ -41,7 +45,7 @@ Counter.propTypes = {
 
 Counter.defaultProps = {
   label: 'Count',
-  count: 0,
+  count: null,
   style: {},
 };
 

--- a/src/components/InteractionsCounter/index.js
+++ b/src/components/InteractionsCounter/index.js
@@ -42,12 +42,14 @@ const styles = StyleSheet.create({
 });
 
 const InteractionsCounter = ({
-  style, likes, comments, ...props
+  style, likes, comments, onPress, ...props
 }) => (
-  <View style={[styles.container, style]}>
-    <Counter label={<LikeIcon {...props} />} count={likes} />
-    <Counter style={styles.commentsCounter} label={<CommentIcon />} count={comments} />
-  </View>
+  <TouchableWithoutFeedback onPress={onPress}>
+    <View style={[styles.container, style]}>
+      <Counter label={<LikeIcon {...props} />} count={likes} />
+      <Counter style={styles.commentsCounter} label={<CommentIcon />} count={comments} />
+    </View>
+  </TouchableWithoutFeedback>
 );
 
 InteractionsCounter.propTypes = {
@@ -62,6 +64,10 @@ InteractionsCounter.propTypes = {
   // number of comments for the thing
   comments: PropTypes.number,
 
+  // callback invoked when the entire control is pressed.
+  // If present, overrides other onPress* callbacks.
+  onPress: PropTypes.func,
+
   // callback invoked when the 'like' icon is pressed for the thing.
   // arguments TBD
   onPressLike: PropTypes.func,
@@ -74,8 +80,9 @@ InteractionsCounter.propTypes = {
 InteractionsCounter.defaultProps = {
   style: {},
   liked: false,
-  likes: 0,
-  comments: 0,
+  likes: null,
+  comments: null,
+  onPress: () => {},
   onPressLike: () => {},
   onPressComment: () => {},
 };

--- a/src/screens/PlayerScreen/index.js
+++ b/src/screens/PlayerScreen/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Platform, Text, View, StyleSheet } from 'react-native';
+import { Easing, Platform, Text, View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
+import TextTicker from 'react-native-text-ticker';
 
 import { FontAwesome } from '@expo/vector-icons';
 
@@ -94,7 +95,14 @@ class PlayerScreen extends React.Component {
           }
         </View>
         <View style={styles.mediaContainer}>
-          <Text style={styles.title}>{item ? item.title : ''}</Text>
+          <TextTicker
+            style={styles.title}
+            scrollSpeed={25}
+            marqueeDelay={2000}
+            easing={Easing.linear}
+          >
+            {item ? item.title : ''}
+          </TextTicker>
           <Text style={styles.seriesTitle}>{getSeriesTitle(item)}</Text>
           <AudioTimeline style={styles.timeline} />
           <Controls style={styles.controls} />

--- a/src/state/models/LiturgyItem.js
+++ b/src/state/models/LiturgyItem.js
@@ -22,6 +22,7 @@ LiturgyItem.fields = {
   contributors: many('Contributor', 'liturgyItems'),
   patronsOnly: attr(),
   isFreePreview: attr(),
+  discourseTopicUrl: attr(),
   createdAt: attr(),
   updatedAt: attr(),
 };
@@ -37,6 +38,7 @@ LiturgyItem.propTypes = {
   publishedAt: PropTypes.string,
   patronsOnly: PropTypes.bool,
   isFreePreview: PropTypes.bool,
+  discourseTopicUrl: PropTypes.string,
   createdAt: PropTypes.string,
   updatedAt: PropTypes.string,
 };

--- a/src/state/models/Meditation.js
+++ b/src/state/models/Meditation.js
@@ -21,6 +21,7 @@ Meditation.fields = {
   category: fk('MeditationCategory', 'meditations'),
   tags: many('Tag'),
   contributors: many('Contributor', 'meditations'),
+  discourseTopicUrl: attr(),
   createdAt: attr(),
   updatedAt: attr(),
 };
@@ -35,6 +36,7 @@ Meditation.propTypes = {
   publishedAt: PropTypes.string,
   patronsOnly: PropTypes.bool,
   isFreePreview: PropTypes.bool,
+  discourseTopicUrl: PropTypes.string,
   createdAt: PropTypes.string,
   updatedAt: PropTypes.string,
 };

--- a/src/state/models/PodcastEpisode.js
+++ b/src/state/models/PodcastEpisode.js
@@ -23,6 +23,7 @@ PodcastEpisode.fields = {
   contributors: many('Contributor', 'podcastEpisodes'),
   patronsOnly: attr(),
   isFreePreview: attr(),
+  discourseTopicUrl: attr(),
   createdAt: attr(),
   updatedAt: attr(),
 };
@@ -38,6 +39,7 @@ PodcastEpisode.propTypes = {
   publishedAt: PropTypes.string,
   patronsOnly: PropTypes.bool,
   isFreePreview: PropTypes.bool,
+  discourseTopicUrl: PropTypes.string,
   createdAt: PropTypes.string,
   updatedAt: PropTypes.string,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10893,6 +10893,11 @@ react-native-tab-view@^1.4.1:
   dependencies:
     prop-types "^15.6.1"
 
+react-native-text-ticker@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/react-native-text-ticker/-/react-native-text-ticker-0.18.0.tgz#a675b292661f3d8bec5c4c1ceae4e6ff03bbc750"
+  integrity sha512-6dosdquyDnAMeihboHp+AtuRr3SKmoDBKNQRB3SM2Umm/8olCaJbYa/eYN/tbbEoGWS9vYWaWyhUq1JFlM5c8g==
+
 react-native-unimodules@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/react-native-unimodules/-/react-native-unimodules-0.4.0.tgz#34127fe881aa3b3ee8f8eae8280b2720252efa36"


### PR DESCRIPTION
## Description
Adds a likes/comments counter in individual media item screens, populated from and linking to Discourse. Uses the `discourseTopicUrl` field in the Contentful entries for `podcastEpisode`, `meditation`, and `liturgyItem`.

[Design](https://projects.invisionapp.com/d/main?origin=v7#/console/12356801/259676370/preview#project_console)

## Motivation and Context
Discourse is going to be the central place for discussions on the podcasts and other media, and its API makes it real simple to grab like and post counts, so this is a simple first pass at integrating Discourse into the app.

## How Has This Been Tested?
- Counters appear when the `discourseTopicUrl` field is set
- Counters don't appear when the field is not set

## Demo
https://youtu.be/scaAx98fkLU