### PR TITLE
Replace disallowed chars in expo release channel name

### DIFF
--- a/ci/deploy-to-expo.sh
+++ b/ci/deploy-to-expo.sh
@@ -26,7 +26,7 @@ prefix=
 if [[ "$1" == "storybook" ]]; then
   prefix="storybook-"
 fi
-channel=${CIRCLE_BRANCH}
+channel=$(echo ${CIRCLE_BRANCH} | sed -E 's/[^A-Za-z0-9_-]+/-/g')
 if [[ "${channel}" == "master" ]]; then
   channel="default"
 fi

--- a/ci/post-expo-comment.js
+++ b/ci/post-expo-comment.js
@@ -83,7 +83,7 @@ const vars = _.mapValues(requiredEnvVars, (name) => {
   return process.env[name];
 });
 
-vars.channel = vars.branch === 'master' ? 'default' : vars.branch;
+vars.channel = vars.branch === 'master' ? 'default' : vars.branch.replace(/[^A-Za-z0-9_-]+/g, '-');
 
 // CircleCI docs say that CIRCLE_PR_NUMBER should be defined,
 // but it's not. Work around it by pulling the number


### PR DESCRIPTION
Fixes expo deploy issue seen in #201.