### PR TITLE
Open Discourse links without leaving the app

### DIFF
--- a/src/components/PlayableItemHeader.js
+++ b/src/components/PlayableItemHeader.js
@@ -9,7 +9,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import * as Progress from 'react-native-progress';
 import TextTicker from 'react-native-text-ticker';
 import axios from 'axios';
-import { Linking } from 'expo';
+import * as WebBrowser from 'expo-web-browser';
 
 import PlayButton from './PlayButton';
 import SquareImage from './SquareImage';
@@ -202,7 +202,7 @@ const PlayableItemHeader = ({
                 likes={likes}
                 comments={comments}
                 onPress={() => {
-                  Linking.openURL(item.discourseTopicUrl);
+                  WebBrowser.openBrowserAsync(item.discourseTopicUrl);
                 }}
               />
             ) : null


### PR DESCRIPTION
## Description
Switched from Expo's `Linking.openURL` to Expo's `WebBrowser.openBrowserAsync`. Now the Discourse links open in the app, in a browser screen dismissible with a "Done" button.

## Motivation and Context
Closes #210.

## How Has This Been Tested?
- Tapped a comment button; observed Discourse opened in popup without leaving the app. Logged in and saw correct topic.
- Closed the window; navigated to another item; opened its Discourse topic. Noticed that I did _not_ have to log in again.

## Demo
https://youtu.be/HPAidhjyNE0