### PR TITLE
Fix null sound error

### DIFF
--- a/src/screens/WelcomeScreen.js
+++ b/src/screens/WelcomeScreen.js
@@ -195,10 +195,12 @@ class Sample extends React.Component {
 
   componentWillUnmount() {
     const { sound } = this.state;
-    sound.setOnPlaybackStatusUpdate(null);
-    sound.stopAsync().then(
-      () => sound.unloadAsync(),
-    );
+    if (sound) {
+      sound.setOnPlaybackStatusUpdate(null);
+      sound.stopAsync().then(
+        () => sound.unloadAsync(),
+      );
+    }
   }
 
   togglePlayback() {


### PR DESCRIPTION
Found in Google Play automated testing:

```
java.lang.RuntimeException: Expo encountered a fatal error: TypeError: null is not an object 
(evaluating 't.setOnPlaybackStatusUpdate')
```