### PR TITLE
Gracefully handle Patreon device verification

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,6 +63,7 @@
       android:name=".LauncherActivity"
       android:exported="true"
       android:launchMode="singleTask"
+      android:configChanges="orientation"
       android:theme="@android:style/Theme.Translucent.NoTitleBar">
     </activity>
 

--- a/ios/the-liturgists/Supporting/Info.plist
+++ b/ios/the-liturgists/Supporting/Info.plist
@@ -92,8 +92,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -78,7 +78,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const newPatronText = `
+const notConnectedText = `
 Log in and connect your account
 to access meditations, liturgies, and
 other bonus content.
@@ -107,18 +107,44 @@ Patreon! You enable us to create even more
 great content.
 `.trim();
 
+const nonPatronText = `
+You are not currently a patron
+of The Liturgists.
+`.trim();
+
+const waitingForDeviceVerificationText = `
+Please check your email to verify your
+device with Patreon.
+`.trim();
+
+function getPatronStatus(
+  isConnected,
+  isPatron,
+  waitingForDeviceVerification,
+) {
+  if (isConnected) {
+    return isPatron ? currentPatreonText : nonPatronText;
+  }
+
+  if (waitingForDeviceVerification) {
+    return waitingForDeviceVerificationText;
+  }
+  return notConnectedText;
+}
 
 const PatreonStatus = ({
+  isConnected,
   isPatron,
+  waitingForDeviceVerification,
   patronFirstName,
   canAccessMeditations,
 }) => (
   <View style={styles.status}>
     <Text style={styles.heading}>
-      {isPatron ? `Hello ${patronFirstName}!` : 'Connect Patreon'}
+      {isConnected ? `Hello ${patronFirstName}!` : 'Connect Patreon'}
     </Text>
     <Text style={styles.text}>
-      {isPatron ? currentPatreonText : newPatronText}
+      {getPatronStatus(isConnected, isPatron, waitingForDeviceVerification)}
     </Text>
     {
       isPatron ? (
@@ -136,7 +162,9 @@ const PatreonStatus = ({
 );
 
 PatreonStatus.propTypes = {
+  isConnected: PropTypes.bool.isRequired,
   isPatron: PropTypes.bool.isRequired,
+  waitingForDeviceVerification: PropTypes.bool.isRequired,
   patronFirstName: PropTypes.string.isRequired,
   canAccessMeditations: PropTypes.bool.isRequired,
 };
@@ -282,6 +310,7 @@ const PatreonScreen = props => (
 PatreonScreen.propTypes = {
   isConnected: PropTypes.bool.isRequired,
   isPatron: PropTypes.bool.isRequired,
+  waitingForDeviceVerification: PropTypes.bool.isRequired,
   navigation: appPropTypes.navigation.isRequired,
 };
 
@@ -300,6 +329,7 @@ function mapStateToProps(state) {
   return {
     isConnected: selectors.isConnected(state),
     isPatron: selectors.isPatron(state),
+    waitingForDeviceVerification: selectors.waitingForDeviceVerification(state),
     patronFirstName: selectors.firstName(state),
     canAccessPatronPodcasts: selectors.canAccessPatronPodcasts(state),
     canAccessMeditations: selectors.canAccessMeditations(state),

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -234,6 +234,7 @@ PatreonButton.defaultProps = {
 
 const PatreonConnectButton = ({
   isConnected,
+  connect: connectPatreon,
   disconnect,
   navigation,
 }) => {
@@ -254,7 +255,10 @@ const PatreonConnectButton = ({
           },
         ],
       )
-      : () => navigation.navigate('PatreonAuth')
+      : () => {
+        connectPatreon();
+        navigation.navigate('PatreonAuth');
+      }
   );
   const opacity = isConnected ? 0.5 : 1.0;
 
@@ -269,6 +273,7 @@ const PatreonConnectButton = ({
 
 PatreonConnectButton.propTypes = {
   isConnected: PropTypes.bool.isRequired,
+  connect: PropTypes.func.isRequired,
   disconnect: PropTypes.func.isRequired,
   navigation: appPropTypes.navigation.isRequired,
 };

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -44,6 +44,13 @@ const styles = StyleSheet.create({
     fontSize: 17,
     textAlign: 'center',
   },
+  verification: {
+    color: 'white',
+    fontWeight: '600',
+    fontSize: 17,
+    textAlign: 'center',
+    marginTop: 10,
+  },
   disclaimer: {
     color: 'white',
     fontSize: 12,
@@ -120,15 +127,11 @@ device with Patreon.
 function getPatronStatus(
   isConnected,
   isPatron,
-  waitingForDeviceVerification,
 ) {
   if (isConnected) {
     return isPatron ? currentPatreonText : nonPatronText;
   }
 
-  if (waitingForDeviceVerification) {
-    return waitingForDeviceVerificationText;
-  }
   return notConnectedText;
 }
 
@@ -144,8 +147,15 @@ const PatreonStatus = ({
       {isConnected ? `Hello ${patronFirstName}!` : 'Connect Patreon'}
     </Text>
     <Text style={styles.text}>
-      {getPatronStatus(isConnected, isPatron, waitingForDeviceVerification)}
+      {getPatronStatus(isConnected, isPatron)}
     </Text>
+    {
+      waitingForDeviceVerification ? (
+        <Text style={styles.verification}>
+          {waitingForDeviceVerificationText}
+        </Text>
+      ) : null
+    }
     {
       isPatron ? (
         <React.Fragment>

--- a/src/state/ducks/patreon/actions.js
+++ b/src/state/ducks/patreon/actions.js
@@ -47,3 +47,11 @@ export const storeDetails = createAction(types.STORE_DETAILS);
  * @param payload {Error}: the error object from the API request
  */
 export const storeError = createAction(types.ERROR);
+
+/**
+ * Set a flag indicating that we are waiting for the user to complete
+ * Patreon device verification (check their email) and connect again.
+ */
+export const setWaitingForDeviceVerification = createAction(
+  types.SET_WAITING_FOR_DEVICE_VERIFICATION,
+);

--- a/src/state/ducks/patreon/constants.js
+++ b/src/state/ducks/patreon/constants.js
@@ -1,5 +1,5 @@
 export const BASE_URL = 'https://www.patreon.com';
-export const CAMPAIGN_SLUG = 'theliturgistspodcast';
+export const CAMPAIGN_SLUG = 'theliturgists';
 export const CAMPAIGN_URL = `${BASE_URL}/${CAMPAIGN_SLUG}`;
 export const PLEDGE_SLUG = `join/${CAMPAIGN_SLUG}`;
 export const PLEDGE_URL = `${BASE_URL}/${PLEDGE_SLUG}`;

--- a/src/state/ducks/patreon/reducer.js
+++ b/src/state/ducks/patreon/reducer.js
@@ -7,6 +7,7 @@ import {
   GET_DETAILS,
   STORE_DETAILS,
   ERROR,
+  SET_WAITING_FOR_DEVICE_VERIFICATION,
 } from './types';
 
 /* patreon reducer state shape:
@@ -25,6 +26,7 @@ import {
 const defaultState = {
   token: null,
   loading: false,
+  waitingForDeviceVerification: false,
 };
 
 export default handleActions({
@@ -32,6 +34,7 @@ export default handleActions({
     ...state,
     error: null,
     loading: true,
+    waitingForDeviceVerification: false,
   }),
   [DISCONNECT]: () => ({
     token: null,
@@ -54,5 +57,10 @@ export default handleActions({
     ...state,
     error: action.payload,
     loading: false,
+  }),
+  [SET_WAITING_FOR_DEVICE_VERIFICATION]: state => ({
+    ...state,
+    loading: false,
+    waitingForDeviceVerification: true,
   }),
 }, defaultState);

--- a/src/state/ducks/patreon/selectors.js
+++ b/src/state/ducks/patreon/selectors.js
@@ -64,3 +64,7 @@ export function loading(state) {
 export function error(state) {
   return state.patreon.error;
 }
+
+export function waitingForDeviceVerification(state) {
+  return !!state.patreon.waitingForDeviceVerification;
+}

--- a/src/state/ducks/patreon/types.js
+++ b/src/state/ducks/patreon/types.js
@@ -8,3 +8,6 @@ export const REFRESH_ACCESS_TOKEN = scopedType('patreon/REFRESH_ACCESS_TOKEN');
 export const STORE_TOKEN = scopedType('patreon/STORE_TOKEN');
 export const STORE_DETAILS = scopedType('patreon/STORE_DETAILS');
 export const ERROR = scopedType('patreon/ERROR');
+export const SET_WAITING_FOR_DEVICE_VERIFICATION = scopedType(
+  'patreon/SET_WAITING_FOR_DEVICE_VERIFICATION',
+);


### PR DESCRIPTION
# Description
The first time a user logs into Patreon from a new device, it goes
through an email-based device verification. The user has to open their
email and click a link, then try logging in again. Since this breaks the
oauth flow in our app, we simply navigate back to the patreon screen and
display a message reminding the user to check their email and try again.

Other Patreon fixes:
- Added text distinguishing between not-connected and not-a-patron
- Updated patreon campaign URL (it was changed in Patreon at some point)

## Demo

https://youtu.be/sD-a7G4ae1Q