### PR TITLE
Show absolute dates for items older than 6 days

### DIFF
--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -10,6 +10,10 @@ export function formatMinutesString(durationStr, elapsed = moment.duration()) {
 }
 
 export function formatHumanizeFromNow(publishedAt) {
+  const _publishedAt = moment(publishedAt);
+  if (_publishedAt.isBefore(moment().subtract(6, 'days'))) {
+    return _publishedAt.format('MMMM Do, YYYY');
+  }
   return `${moment(publishedAt).fromNow()}`;
 }
 


### PR DESCRIPTION
## Description
I was scrolling through old items and seeing a whole bunch of "a year ago" in a row, which was not very informative. After chatting with @tannerhearne , we agreed to use relative dates for just the most recent items (most recent 6 days) and absolute dates for everything older.

## Screenshot
<img width="584" alt="Screen Shot 2020-03-06 at 11 26 10 PM" src="https://user-images.githubusercontent.com/91550/76136790-6ee6a880-6003-11ea-85af-a5a3ac9a7157.png">
