### PR TITLE
Add scope to notification topics

### DIFF
--- a/ci/deploy-to-expo.sh
+++ b/ci/deploy-to-expo.sh
@@ -18,6 +18,7 @@ fi
 api_url="https://staging.api.theliturgists.com"
 json -I -f config.json \
   -e "this.apiBaseUrl='${api_url}'" \
+  -e "this.notificationScope='staging'" \
   -e "this.sentryPublicDSN='${SENTRY_DSN}'"
 
 expo login -u "${EXPO_USERNAME}" -p "${EXPO_PASSWORD}"

--- a/config.json.example
+++ b/config.json.example
@@ -1,3 +1,4 @@
 {
-    "apiBaseUrl": "https://staging.api.theliturgists.com"
+    "apiBaseUrl": "https://staging.api.theliturgists.com",
+    "notificationScope": "staging"
 }

--- a/src/state/ducks/notifications/epic.js
+++ b/src/state/ducks/notifications/epic.js
@@ -22,10 +22,8 @@ function subscribe(messaging, topic) {
   console.log(`Subscribing to topic: "${scopedTopic}"`);
   messaging.subscribeToTopic(scopedTopic);
 
-  // Keep subscribing to unscoped topic for a while to allow
-  // all clients to upgrade. Can switch to unsubscribe later,
-  // and remove entirely before launch.
-  messaging.subscribeToTopic(topic);
+  // Unsubscribe old clients from the unscoped topic after upgrade
+  messaging.unsubscribeFromTopic(topic);
 }
 
 function unsubscribe(messaging, topic) {

--- a/src/state/ducks/notifications/epic.js
+++ b/src/state/ducks/notifications/epic.js
@@ -9,10 +9,35 @@ import { UPDATE_PATRON_NOTIFICATION_SUBSCRIPTIONS } from './types';
 import { STORE_DETAILS, DISCONNECT } from '../patreon/types';
 import { canAccessMeditations, canAccessPatronPodcasts } from '../patreon/selectors';
 
+import config from '../../../../config.json';
+
 const publicTopicName = 'new-public-media';
 const patronPodcastsTopicName = 'new-patron-podcast';
 const patronMeditationsTopicName = 'new-patron-meditation';
-const patronLiturgiesTopicName = 'new-patron-liturgy';
+// const patronLiturgiesTopicName = 'new-patron-liturgy';
+
+function subscribe(messaging, topic) {
+  const scope = config.notificationScope;
+  const scopedTopic = `${topic}-${scope}`;
+  console.log(`Subscribing to topic: "${topic}"`);
+  messaging.subscribeToTopic(scopedTopic);
+
+  // Keep subscribing to unscoped topic for a while to allow
+  // all clients to upgrade. Can switch to unsubscribe later,
+  // and remove entirely before launch.
+  messaging.subscribeToTopic(topic);
+}
+
+function unsubscribe(messaging, topic) {
+  const scope = config.notificationScope;
+  const scopedTopic = `${topic}-${scope}`;
+  console.log(`Unsubscribing from topic: "${topic}"`);
+  messaging.unsubscribeFromTopic(scopedTopic);
+
+  // Keep unsubscribing from unscoped topic for a while to allow
+  // all clients to upgrade. Can remove before launch.
+  messaging.unsubscribeFromTopic(topic);
+}
 
 const registerEpic = action$ =>
   action$.pipe(
@@ -36,8 +61,7 @@ const registerEpic = action$ =>
                 newToken => subscriber.next(saveToken(newToken)),
               );
 
-              console.log(`Subscribing to topic: "${publicTopicName}"`);
-              messaging.subscribeToTopic(publicTopicName);
+              subscribe(messaging, publicTopicName);
             });
 
           messaging.hasPermission()
@@ -68,25 +92,29 @@ const updatePatronNotificationSubscriptionsEpic = (action$, state$) =>
     ofType(UPDATE_PATRON_NOTIFICATION_SUBSCRIPTIONS),
     switchMap(() => {
       const messaging = firebase.messaging();
+      const subscribeTopics = [];
+      const unsubscribeTopics = [];
+
       if (canAccessPatronPodcasts(state$.value)) {
-        console.log(`Subscribing to topic: "${patronPodcastsTopicName}"`);
-        messaging.subscribeToTopic(patronPodcastsTopicName);
+        subscribeTopics.push(patronPodcastsTopicName);
       } else {
-        console.log(`Unsubscribing from topic: "${patronPodcastsTopicName}"`);
-        messaging.unsubscribeFromTopic(patronPodcastsTopicName);
+        unsubscribeTopics.push(patronPodcastsTopicName);
       }
 
       if (canAccessMeditations(state$.value)) {
-        console.log(`Subscribing to topic: "${patronMeditationsTopicName}"`);
-        messaging.subscribeToTopic(patronMeditationsTopicName);
-        console.log(`Subscribing to topic: "${patronLiturgiesTopicName}"`);
-        messaging.subscribeToTopic(patronLiturgiesTopicName);
+        subscribeTopics.push(patronMeditationsTopicName);
       } else {
-        console.log(`Unsubscribing from topic: "${patronMeditationsTopicName}"`);
-        messaging.unsubscribeFromTopic(patronMeditationsTopicName);
-        console.log(`Unsubscribing from topic: "${patronLiturgiesTopicName}"`);
-        messaging.unsubscribeFromTopic(patronLiturgiesTopicName);
+        unsubscribeTopics.push(patronMeditationsTopicName);
       }
+
+
+      subscribeTopics.forEach((topic) => {
+        subscribe(messaging, topic);
+      });
+
+      unsubscribeTopics.forEach((topic) => {
+        unsubscribe(messaging, topic);
+      });
 
       return Observable.never();
     }),

--- a/src/state/ducks/notifications/epic.js
+++ b/src/state/ducks/notifications/epic.js
@@ -19,7 +19,7 @@ const patronMeditationsTopicName = 'new-patron-meditation';
 function subscribe(messaging, topic) {
   const scope = config.notificationScope;
   const scopedTopic = `${topic}-${scope}`;
-  console.log(`Subscribing to topic: "${topic}"`);
+  console.log(`Subscribing to topic: "${scopedTopic}"`);
   messaging.subscribeToTopic(scopedTopic);
 
   // Keep subscribing to unscoped topic for a while to allow
@@ -31,7 +31,7 @@ function subscribe(messaging, topic) {
 function unsubscribe(messaging, topic) {
   const scope = config.notificationScope;
   const scopedTopic = `${topic}-${scope}`;
-  console.log(`Unsubscribing from topic: "${topic}"`);
+  console.log(`Unsubscribing from topic: "${scopedTopic}"`);
   messaging.unsubscribeFromTopic(scopedTopic);
 
   // Keep unsubscribing from unscoped topic for a while to allow


### PR DESCRIPTION
## Description
Enable "scoped" notifications, with a scope manually defined in `config.json`.

## Motivation and Context
By default, the app uses the staging backend URL and the `staging` notification scope, so real notifications from the staging backend will show up in the app. If the app is configured instead to use a custom dev backend, it should also be configured to use a notification scope that matches the namespace of that backend; i.e. `<username>-dev`. This allows development and testing of notifications only for that dev build, without notifying real users.

## How Has This Been Tested?
See theliturgists/backend#24