### PR TITLE
Use patron access API in app

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@react-native-community/async-storage": "^1.7.1",
     "@react-native-firebase/app": "^6.4.0",
     "@react-native-firebase/messaging": "^6.4.0",
-    "@theliturgists/patreon-pledge": "^0.2.0",
     "@theliturgists/redux-orm-proptypes": "^0.1.1",
     "app-icon": "^0.13.0",
     "axios": "^0.18.0",

--- a/src/screens/PatreonScreen.js
+++ b/src/screens/PatreonScreen.js
@@ -96,15 +96,20 @@ This app does not store, read, or even
 think about your Patreon credentials.
 `.trim();
 
-function patronRewards(canAccessMeditations) {
-  const extras = canAccessMeditations ? `
-    - Meditations
-    - Liturgies
-  ` : '';
+function patronRewards(patronPodcasts, canAccessMeditations, canAccessLiturgies) {
+  const extras = [];
+  if (canAccessMeditations) {
+    extras.push('- Meditations');
+  }
+  if (canAccessLiturgies) {
+    extras.push('- Liturgies');
+  }
+
+  const podcasts = patronPodcasts.map(pod => `- ${pod.title}`).join('\n');
 
   return `
-    - Bonus podcast
-    ${extras.trim()}
+    ${podcasts}
+    ${extras.join('\n')}
   `.trim();
 }
 
@@ -140,7 +145,9 @@ const PatreonStatus = ({
   isPatron,
   waitingForDeviceVerification,
   patronFirstName,
+  patronPodcasts,
   canAccessMeditations,
+  canAccessLiturgies,
 }) => (
   <View style={styles.status}>
     <Text style={styles.heading}>
@@ -163,7 +170,7 @@ const PatreonStatus = ({
             {'You currently have access to:\n'}
           </Text>
           <Text style={styles.text}>
-            {patronRewards(canAccessMeditations)}
+            {patronRewards(patronPodcasts, canAccessMeditations, canAccessLiturgies)}
           </Text>
         </React.Fragment>
       ) : null
@@ -176,7 +183,9 @@ PatreonStatus.propTypes = {
   isPatron: PropTypes.bool.isRequired,
   waitingForDeviceVerification: PropTypes.bool.isRequired,
   patronFirstName: PropTypes.string.isRequired,
+  patronPodcasts: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   canAccessMeditations: PropTypes.bool.isRequired,
+  canAccessLiturgies: PropTypes.bool.isRequired,
 };
 
 const patreonStyles = {
@@ -346,8 +355,10 @@ function mapStateToProps(state) {
     isPatron: selectors.isPatron(state),
     waitingForDeviceVerification: selectors.waitingForDeviceVerification(state),
     patronFirstName: selectors.firstName(state),
+    patronPodcasts: selectors.patronPodcasts(state),
     canAccessPatronPodcasts: selectors.canAccessPatronPodcasts(state),
     canAccessMeditations: selectors.canAccessMeditations(state),
+    canAccessLiturgies: selectors.canAccessLiturgies(state),
     loading: selectors.loading(state),
     error: selectors.error(state),
   };

--- a/src/state/ducks/notifications/epic.js
+++ b/src/state/ducks/notifications/epic.js
@@ -7,7 +7,7 @@ import { mergeMap, switchMap } from 'rxjs/operators';
 import { saveToken, updatePatronNotificationSubscriptions } from './actions';
 import { UPDATE_PATRON_NOTIFICATION_SUBSCRIPTIONS } from './types';
 import { STORE_DETAILS, DISCONNECT } from '../patreon/types';
-import { canAccessMeditations, canAccessPatronPodcasts } from '../patreon/selectors';
+import { canAccessMeditations, patronPodcasts } from '../patreon/selectors';
 
 import config from '../../../../config.json';
 
@@ -85,7 +85,7 @@ const updatePatronNotificationSubscriptionsEpic = (action$, state$) =>
       const subscribeTopics = [];
       const unsubscribeTopics = [];
 
-      if (canAccessPatronPodcasts(state$.value)) {
+      if (patronPodcasts(state$.value).length > 0) {
         subscribeTopics.push(patronPodcastsTopicName);
       } else {
         unsubscribeTopics.push(patronPodcastsTopicName);

--- a/src/state/ducks/patreon/epic.js
+++ b/src/state/ducks/patreon/epic.js
@@ -24,16 +24,13 @@ axiosRetry(axios, {
 });
 
 function getPatreonDetails(token) {
-  const detailsUrl = `${config.apiBaseUrl}/patreon/api/current_user`;
+  const detailsUrl = `${config.apiBaseUrl}/patron-pledge`;
   return from(
     axios.get(
       detailsUrl,
       {
         headers: {
           'x-theliturgists-token': token,
-        },
-        params: {
-          includes: 'pledges',
         },
       },
     )

--- a/src/state/ducks/patreon/selectors.js
+++ b/src/state/ducks/patreon/selectors.js
@@ -1,7 +1,5 @@
 import _ from 'lodash';
 
-import Pledge from '@theliturgists/patreon-pledge';
-
 import * as authSelectors from '../auth/selectors';
 
 export function isConnected(state) {
@@ -9,22 +7,34 @@ export function isConnected(state) {
 }
 
 export function getPledge(state) {
-  return new Pledge(state?.patreon?.details);
+  // TODO: look up pledge API object from state
+  // TODO before that: make sure we've fetched it
+  return state?.patreon?.details;
 }
 
 export function isPatron(state) {
   const pledge = getPledge(state);
-  return pledge.isPatron();
+  return pledge?.isPatron || false;
 }
 
 export function canAccessPatronPodcasts(state) {
   const pledge = getPledge(state);
-  return pledge.canAccessPatronPodcasts();
+  return pledge?.canAccessPatronPodcasts || false;
+}
+
+export function patronPodcasts(state) {
+  const pledge = getPledge(state);
+  return pledge?.podcasts || [];
 }
 
 export function canAccessMeditations(state) {
   const pledge = getPledge(state);
-  return pledge.canAccessMeditations();
+  return pledge?.canAccessMeditations || false;
+}
+
+export function canAccessLiturgies(state) {
+  const pledge = getPledge(state);
+  return pledge?.canAccessLiturgies || false;
 }
 
 export function imageUrl(state) {
@@ -36,11 +46,11 @@ export function imageUrl(state) {
 }
 
 export function firstName(state) {
-  return _.get(state.patreon, 'details.data.attributes.first_name', '');
+  return _.get(state.patreon, 'details.userData.data.attributes.first_name', '');
 }
 
 export function fullName(state) {
-  return _.get(state.patreon, 'details.data.attributes.full_name', 'Patreon');
+  return _.get(state.patreon, 'details.userData.data.attributes.full_name', 'Patreon');
 }
 
 export function loading(state) {


### PR DESCRIPTION
## Description
Implements the app side of theliturgists/backend#27. The app now uses the API defined there to 

## Motivation and Context
Closes #238.

## How Has This Been Tested?
Tested with my own patreon login.
- Verified that the settings from the Contentful tier show up in the app
  - Now includes individual podcasts by name
  - Now allows separated meditations/liturgies access (mainly useful for testing)
- Tweaked the settings in the tier; watched the display and access controls match on refresh