### PR TITLE
Use Slack invite link instead of defunct survey

### DIFF
--- a/src/components/SocialLinksSection.js
+++ b/src/components/SocialLinksSection.js
@@ -59,7 +59,7 @@ const links = [
   },
   {
     imageSource: slackIcon,
-    url: 'http://bit.ly/JoinLiturgistsSlack',
+    url: 'https://join.slack.com/t/theliturgistsspace/shared_invite/enQtODY2MTA2OTI0NDIzLWZhYjIzZmQ3NTI3YTFiY2Q2M2M2NDQwODUwYmYzMTFhNmYwZmUwMWVmZWU4NmY3MzcwYzVkNDFlMWY1ZTAzMjI',
     style: styles.slackIconContainer,
     label: 'Discuss in Slack',
   },


### PR DESCRIPTION
## Description
Survey went away a while ago; this is the way people join now.

## Motivation and Context
Already used on the website; old method was broken.

## How Has This Been Tested?
I can't test it, since I've already joined the slack - but it seemed to do the right thing when I was logged out of Slack.